### PR TITLE
Some cleanup and fixes

### DIFF
--- a/gap/CreateDocumentationEntries.gi
+++ b/gap/CreateDocumentationEntries.gi
@@ -18,7 +18,7 @@ InstallGlobalFunction( CreateDocEntryForCategory,
     
     if not Length( arg ) in [ 3 .. 6 ] then
         
-        Error( "the method CreateDocEntryForCategory must be called with 3, 4, 5 or 6 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -205,7 +205,7 @@ InstallGlobalFunction( CreateDocEntryForRepresentation,
     
     if not Length( arg ) in [ 4 .. 7 ] then
         
-        Error( "the method DeclareCategoryWithDocumentation must be called with 4, 5, 6 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -394,7 +394,7 @@ InstallGlobalFunction( CreateDocEntryForOperation,
     
     if not Length( arg ) in [ 4 .. 7 ] then
         
-        Error( "the method CreateDocEntryForOperation must be called with 4, 5, 6 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -596,7 +596,7 @@ InstallGlobalFunction( CreateDocEntryForAttribute,
     
     if not Length( arg ) in [ 4 .. 7 ] then
         
-        Error( "the method CreateDocEntryWithAttribute must be called with 4, 5, 6 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -798,7 +798,7 @@ InstallGlobalFunction( CreateDocEntryForProperty,
     
     if not Length( arg ) in [ 3, 4, 5, 7 ] then
         
-        Error( "the method CreateDocEntryWithProperty must be called with 3, 4, 5 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         

--- a/gap/InstallMethodWithDocumentation.gi
+++ b/gap/InstallMethodWithDocumentation.gi
@@ -492,7 +492,7 @@ InstallGlobalFunction( DeclareCategoryWithDocumentation,
     
     if not Length( arg ) in [ 3 .. 6 ] then
         
-        Error( "the method DeclareCategoryWithDocumentation must be called with 3, 4, 5 or 6 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -517,7 +517,7 @@ InstallGlobalFunction( DeclareRepresentationWithDocumentation,
     
     if not Length( arg ) in [ 4 .. 7 ] then
         
-        Error( "the method DeclareCategoryWithDocumentation must be called with 4, 5, 6 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -544,7 +544,7 @@ InstallGlobalFunction( DeclareOperationWithDocumentation,
     
     if not Length( arg ) in [ 4 .. 7 ] then
         
-        Error( "the method DeclareOperationWithDocumentation must be called with 4, 5, 6 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -569,7 +569,7 @@ InstallGlobalFunction( DeclareAttributeWithDocumentation,
     
     if not Length( arg ) in [ 4 .. 7 ] then
         
-        Error( "the method DeclareAttributeWithDocumentation must be called with 4, 5, 6 or 7 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -595,7 +595,7 @@ InstallGlobalFunction( DeclarePropertyWithDocumentation,
     
     if not Length( arg ) in [ 3 .. 6 ] then
         
-        Error( "the method DeclarePropertyWithDocumentation must be called with 3, 4, 5, or 6 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -622,7 +622,7 @@ InstallGlobalFunction( InstallMethodWithDocumentation,
     
     if not Length( arg ) in [ 6 .. 8 ] then
         
-        Error( "the method InstallMethodWithDocumentation must be called with 6, 7, or 8 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -769,7 +769,7 @@ InstallGlobalFunction( DeclareGlobalFunctionWithDocumentation,
     
     if not Length( arg ) in [ 3 .. 6 ] then
         
-        Error( "the method DeclareGlobalFunctionWithDocumentation must be called with 3, 4, 5, or 6 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         
@@ -940,7 +940,7 @@ InstallGlobalFunction( DeclareGlobalVariableWithDocumentation,
     
     if not Length( arg ) in [ 2 .. 4 ] then
         
-        Error( "the method DeclareGlobalVariableWithDocumentation must be called with 2, 3 or 4 arguments\n" );
+        Error( "wrong number of arguments\n" );
         
         return false;
         


### PR DESCRIPTION
This simplifies how the number of arguments for various functions are checked. It also fixes multiple places where the number of arguments that were being checked for differed from what the error messages claimed as acceptable.

The last commit indeed replace those error messages by generic ones, which should be easier to maintainer. Since these errors should in 99.9% of all cases only be seen by package authors (or, indeed, only the AutoDoc authors themselves), I think this is a good tradeoff, as developers should be able to determine the acceptable number of arguments by inspecting the code surrounding the Error().
