### PR TITLE
Revise computation of labels

### DIFF
--- a/gap/InstallMethodWithDocumentation.gi
+++ b/gap/InstallMethodWithDocumentation.gi
@@ -19,7 +19,7 @@ InstallValue( AUTOMATIC_DOCUMENTATION,
                 documentation_headers_main_file := false,
                 path_to_xmlfiles := Directory(""),
                 default_chapter := rec( ),
-                random_value := 10^10,
+                label_counter := 0,
                 grouped_items := rec( ),
               )
            );
@@ -455,7 +455,7 @@ InstallGlobalFunction( CreateAutomaticDocumentation,
         
         current_group := AUTOMATIC_DOCUMENTATION.grouped_items.(group_names);
         
-        AutoDoc_WriteGroupedEntry( AUTOMATIC_DOCUMENTATION.documentation_stream, current_group.label_rand_hash, current_group.elements, current_group.return_value, current_group.description, current_group.label_list );
+        AutoDoc_WriteGroupedEntry( AUTOMATIC_DOCUMENTATION.documentation_stream, current_group.label_hash, current_group.elements, current_group.return_value, current_group.description, current_group.label_list );
         
     od;
     


### PR DESCRIPTION
Instead of relying on random numbers, we use a hash of the objects's name,
plus a label counter (which helps to avoid giving things with the same name
the same label).

As hash function we use CRC32, which has the advantage of already being
provided by GAP (and this is what GAPDoc uses, too). Drawback: This is
not a very good hash and collisions are possible. But for our purposes
it should be fine.

Note that with this, we can get rid of the "reset rng seed" hack in AutoDocTestPackage
