### PR TITLE
Allow passing directory objects (instead of package names) to AutoDoc()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,8 @@
+This file describes changes in the AutoDoc package.
+
+2016-01-21:
+  - The AutoDoc() function now accepts IsDirectory() objects
+    as first argument, and you can omit the first argument
+    (it then defaults to the current directory).
+    Packages using AutoDoc may want to adapt their makedoc.g
+    to use this new facility for improved robustness.

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -8,7 +8,7 @@ Subtitle := "Generate documentation from GAP source code",
 Version := Maximum( [
   "2015.12.03", ## Sebas' version
 ## This line prevents merge conflicts
-  "2016.01.20", ## Max' version
+  "2016.01.21", ## Max' version
 ## This line prevents merge conflicts
   "2013.11.01", ## Mohamed's version
 ] ),

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -55,11 +55,18 @@ Persons := [
 Status := "deposited",
 PackageWWWHome := "http://gap-packages.github.io/AutoDoc/",
 
+SourceRepository := rec(
+    Type := "git",
+    URL := Concatenation( "https://github.com/gap-packages/", ~.PackageName ),
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome  := Concatenation( "https://gap-packages.github.io/", ~.PackageName ),
+README_URL      := Concatenation( ~.PackageWWWHome, "/README" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/v", ~.Version,
+                                 "/", ~.PackageName ,"-", ~.Version ),
 ArchiveFormats := ".tar.gz",
-
-ArchiveURL     := Concatenation( ~.PackageWWWHome, "AutoDoc-", ~.Version ),
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 
 AbstractHTML := 
   "",

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -48,9 +48,17 @@
 #! The parameters have the following meanings:
 #! <List>
 #!
-#! <Mark><A>package_name</A></Mark>
+#! <Mark><A>package</A></Mark>
 #! <Item>
-#!     The name of the package whose documentation should be(re)generated.
+#!     This is either the name of package, or an <C>IsDirectory</C> object.
+#!     In the former case, &AutoDoc; uses the metadata of the first package
+#!     with that name known to &GAP;. In the latter case, it checks whether
+#!     the given directory contains a <F>PackageInfo.g</F> file, and extracts
+#!     all needed metadata from that. This is for example useful if you have
+#!     multiple versions of the package around and want to make sure the
+#!     documentation of the correct version is built.
+#!     <P/>
+#!     If this argument is omitted, &AutoDoc; uses the <C>DirectoryCurrent()</C>.
 #! </Item>
 #!
 #!
@@ -70,7 +78,7 @@
 #!     <Mark><A>scaffold</A></Mark>
 #!     <Item>
 #!         This controls whether and how to generate scaffold XML files
-#!         for the main and title page of the package's documentation. 
+#!         for the main and title page of the package's documentation.
 #!         <P/>
 #!         The value should be either <K>true</K>, <K>false</K> or a
 #!         record. If it is a record or <K>true</K> (the latter is
@@ -301,7 +309,7 @@
 #! </List>
 #!
 #! @Returns nothing
-#! @Arguments package_name[, option_record ]
+#! @Arguments [package[, option_record ]]
 #! @ChapterInfo AutoDoc, The AutoDoc() function
 DeclareGlobalFunction( "AutoDoc" );
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,7 +1,6 @@
 LoadPackage("AutoDoc");
 
-AutoDoc(
-    "AutoDoc" : 
+AutoDoc(rec( 
     autodoc := true,
     scaffold := rec(
         includes := [
@@ -13,9 +12,9 @@ AutoDoc(
             "SomePackage",
         ],
     )
-);
+));
 
 # Create VERSION file for "make towww"
-PrintTo( "VERSION", PackageInfo( "AutoDoc" )[1].Version );
+PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version );
 
 QUIT;

--- a/makefile
+++ b/makefile
@@ -2,11 +2,8 @@ all: doc
 
 doc: doc/manual.six
 
-doc/manual.six: makedoc.g \
-		PackageInfo.g \
-		doc/*.xml \
-		gap/*.gd gap/*.gi
-	        gap makedoc.g
+doc/manual.six: makedoc.g PackageInfo.g doc/*.xml gap/*.gd gap/*.gi
+	gap makedoc.g
 
 clean:
 	(cd doc ; ./clean)


### PR DESCRIPTION
This change allows packages to get rid of `SetPackagePath(PACKAGE, ".");` in their `makedoc.g` files, which improves robustness. It is also cruicial for the new `matrices` package <https://github.com/gap-packages/matrices> which cannot use `SetPackagePath` reliably (it is a required package, so always loaded, but `SetPackagePath` is problematic for packages which are loaded).