### PR TITLE
Preserving leading spaces in code blocks, documentation.

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -18,7 +18,7 @@ PackageName := "AutoDoc",
 Subtitle := "Generate documentation from GAP source code",
 
 Version := Maximum( [
-  "2016.03.02", ## Sebas' version
+  "2016.03.03", ## Sebas' version
 ## This line prevents merge conflicts
   "2016.02.24", ## Max' version
 ## This line prevents merge conflicts

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -537,13 +537,12 @@ produces the following:
 </Section>
 
 <Section Label="MarkdownExtension">
-<Heading>Some syntax for &AutoDoc; text</Heading>
+<Heading>Markdown-like formatting of text in &AutoDoc;</Heading>
 
-&AutoDoc; offers some useful syntax extensions which can be used in &AutoDoc; plain text files
-and &AutoDoc; comments. The syntax is inspired by the Markdown language,
-but it does not implement all features, neither is it strict Markdown, but tries to
-be as straight as possible. The following constructions
-are possible right now:
+&AutoDoc; has some convenient ways to insert special format into text, like
+math formulas and lists. The syntax for them are inspired by Markdown and LaTeX,
+but do not follow them strictly. Neither are all features of the Markdown language
+supported. The following subsections describe what is possible.
 
 <Subsection Label="MarkdownExtensionList">
   <Heading>Lists</Heading>

--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -227,6 +227,60 @@ gap maketest.g
 test the examples from your manual.
 </Subsection>
 
+<Subsection Label="Tut:IntegrateExisting:GapDocOptions">
+<Heading>Setting different &GAPDoc; options</Heading>
+
+Sometimes, the default values for the &GAPDoc; command used by &AutoDoc;
+may not be suitable for your manual.
+<P/>
+ Suppose your main xml file is <E>not</E> named <F>PACKAGENAME.xml</F>, but rather something else, e.g. <F>main.xml</F>.
+Then you can tell &AutoDoc; to use this file as the main xml file via
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( gapdoc := rec( main := "main" ) ) );
+</Listing>
+<P/>
+As explained above, by default &AutoDoc; scans all <F>.g</F>, <F>.gd</F> and <F>.gi</F> files
+it can find inside of your package root directory, and in the subdirectories <F>gap</F>,
+<F>lib</F>, <F>examples</F> and <F>examples/doc</F> as well.
+If you keep source files with documentation in other directories,
+you can adjust the list of directories AutoDoc scans via the <C>scan_dirs</C> option.
+The following example illustrates this by instructing &AutoDoc; to only search in the subdirectory <F>package_sources</F>
+of the packages root directory.
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( gapdoc := rec( scan_dirs := [ "package_source" ] ) ) );
+</Listing>
+You can also specify an explicit list of files containing documentation,
+which will be searched in addition to any files located within the scan directories:
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( gapdoc := rec( files := [ "path/to/some/hidden/file.gds" ] ) ) );
+</Listing>
+Giving such a file does not prevent the standard <C>scan_dirs</C> from being scanned for
+other files.
+<P/>
+Next, &GAPDoc; supports the documentation to be built with relative paths.
+This means, links to manuals of other packages or the &GAP; library will
+not be absolute, but relative from your documentation. This can be particulary useful
+if you want to build a release tarball or move your &GAP; installation around later.
+Suppose you are starting &GAP; in the root path of your package as always,
+and the standard call of <Ref Func="AutoDoc"/> will then build the documentation in the <F>doc</F> subfolder of your package.
+From this folder, the gap root directory has the relative path <F>../../..</F>.
+Then you can enable the relative paths by
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( gapdoc := rec( gap_root_relative_path := "../../.." ) ) );
+</Listing>
+or, since <F>../../..</F> is the standard option for <C>gap_root_relative_path</C>, by
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( gapdoc := rec( gap_root_relative_path := true ) ) );
+</Listing>
+
+
+</Subsection>
+
 <Subsection Label="Tut:IntegrateExisting:TitlePage">
   <Heading>Using &AutoDoc;s scaffold for regenerating the title page</Heading>
 

--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -227,8 +227,26 @@ gap maketest.g
 test the examples from your manual.
 </Subsection>
 
-</Section>
+<Subsection Label="Tut:IntegrateExisting:TitlePage">
+  <Heading>Using &AutoDoc;s scaffold for regenerating the title page</Heading>
 
+Suppose the same as above, i.e., a complete manual. Then your title page
+might contain information that can change with every build of the manual, e.g.,
+date, package version, and so on. All of these versions are in the <F>PackageInfo.g</F>
+of the package, and only need to be extracted into a proper title page. &AutoDoc; can do this
+for you. Suppose your title page is <F>doc/title.xml</F> and you want it to be overriden with a
+fresh version everytime you build your manual. Then you can achieve it by telling &AutoDoc;s scaffold
+option to only rebuild the title page.
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( : scaffold := rec( MainPage := false ),
+           autodoc := false );
+</Listing>
+This command will extract information about, title, subtitle, authors, etc from your <F>PackageInfo.g</F>
+and puts them into <F>doc/title.xml</F>. However, no other files from your manual are touched.
+</Subsection>
+
+</Section>
 
 <Section Label="Tut:AutoRegenerate">
 <Heading>Automatic regeneration of the manual</Heading>

--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -181,9 +181,51 @@ There are various examples of packages using &AutoDoc; for only
 this purpose, e.g. <Package>IO</Package> and <Package>orb</Package>.
 <P/>
 
-<!--
-TODO: Explain how to mix AutoDoc content with existing &GAPDoc; XML files.
--->
+<Subsection Label="Tut:IntegrateExisting:EverythingThere">
+  <Heading>Using &AutoDoc; on a complete &GAPDoc; manual</Heading>
+
+Suppose you already have a complete XML manual, with some main and title
+XML files and some documentation for operations distributed over
+all your <F>.g</F>, <F>.gd</F>, and <F>.gi</F> files. Even then &AutoDoc; can do something for you.
+Suppose your main xml file is named <F>PACKAGENAME.xml</F> and is in the
+<F>/doc</F> subfolder of your package. Then calling following the from a GAP started in the root directory
+of your package
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( );
+</Listing>
+will rebuild your manual. As you can see, the <Ref Func="AutoDoc"/> does not take any
+arguments here, which is really convenient.
+<P/>
+To emphasize this even more, the following is taken from the <F>makedoc.g</F> file
+of <Package>RingsForHomalg</Package>.
+<Listing>
+LoadPackage( "GAPDoc" );
+SetGapDocLaTeXOptions( "utf8" );
+bib := ParseBibFiles( "doc/RingsForHomalg.bib" );
+WriteBibXMLextFile( "doc/RingsForHomalgBib.xml", bib );
+Read( "ListOfDocFiles.g" );
+MakeGAPDocDoc( "doc", "RingsForHomalg", list_of_files, "RingsForHomalg" );
+GAPDocManualLab( "RingsForHomalg" );
+</Listing>
+The <C>Read</C> command reads a manually created list of filesnames, which contain
+the names of the implementation files containing parts of the &GAPDoc; manual, and stores them in <C>list_of_files</C>.
+<Br/>
+Calling <Ref Func="AutoDoc"/> like displayed above without any arguments will do the same as the whole <F>makedoc.g</F>
+script, and you do not even have to keep a list of your implementation files.
+<P/>
+But there is more. &AutoDoc; can create a <F>maketest.g</F> file, which uses the
+examples in your manual to test your package. This can be achieved via
+<Listing>
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( maketest := true ) );
+</Listing>
+Now the file <F>maketest.g</F> appears in your package directory, and
+<Listing>
+gap maketest.g
+</Listing>
+test the examples from your manual.
+</Subsection>
 
 </Section>
 

--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -20,7 +20,7 @@ while running &GAP; from within your package's directory (the
 one containing the <F>PackageInfo.g</F>:
 <Listing>
 LoadPackage( "AutoDoc" );
-AutoDoc( : scaffold := true );
+AutoDoc( rec( scaffold := true ) );
 </Listing>
 This first reads the <F>PackageInfo.g</F> file from the current
 directory. It extracts information about package from it
@@ -131,7 +131,8 @@ include all newly documented functions, operations etc.:
 
 <Listing>
 LoadPackage( "AutoDoc" );
-AutoDoc( : scaffold := true, autodoc := true );
+AutoDoc( rec( scaffold := true, 
+              autodoc := true ) );
 </Listing>
 
 If you are not using the scaffolding feature, e.g. because you already
@@ -151,7 +152,7 @@ and the runs &GAPDoc; to produce HTML and PDF output, but does not
 touch your documentation XML files otherwise.
 <Listing>
 LoadPackage( "AutoDoc" );
-AutoDoc( : autodoc := true );
+AutoDoc( rec( autodoc := true ) );
 </Listing>
 
 
@@ -293,8 +294,7 @@ fresh version everytime you build your manual. Then you can achieve it by tellin
 option to only rebuild the title page.
 <Listing>
 LoadPackage( "AutoDoc" );
-AutoDoc( : scaffold := rec( MainPage := false ),
-           autodoc := false );
+AutoDoc( rec( scaffold := rec( MainPage := false ) ) );
 </Listing>
 This command will extract information about, title, subtitle, authors, etc from your <F>PackageInfo.g</F>
 and puts them into <F>doc/title.xml</F>. However, no other files from your manual are touched.
@@ -313,7 +313,7 @@ recommend putting its invocation into a file <F>makedoc.g</F> in your package
 directory, with content based on the following example:
 <Listing>
 LoadPackage( "AutoDoc" );
-AutoDoc( : autodoc := true );
+AutoDoc( rec( autodoc := true ) );
 QUIT;
 </Listing>
 Then you can regenerate the package manual from the command line with the

--- a/gap/DocumentationTree.gd
+++ b/gap/DocumentationTree.gd
@@ -57,6 +57,8 @@ DeclareOperation( "DocumentationExample", [ IsTreeForDocumentation, IsList ] );
 DeclareOperation( "DocumentationExample", [ IsTreeForDocumentation ] );
 DeclareOperation( "DocumentationDummy", [ IsTreeForDocumentation, IsString, IsList ] );
 DeclareOperation( "DocumentationDummy", [ IsTreeForDocumentation, IsString ] );
+DeclareOperation( "DocumentationCode", [ IsTreeForDocumentation, IsString, IsList ] );
+DeclareOperation( "DocumentationCode", [ IsTreeForDocumentation, IsString ] );
 DeclareOperation( "DocumentationManItem", [ IsTreeForDocumentation ] );
 DeclareOperation( "SetManItemToDescription", [ IsTreeForDocumentationNode ] );
 DeclareOperation( "SetManItemToReturnValue", [ IsTreeForDocumentationNode ] );

--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -109,6 +109,14 @@ BindGlobal( "TheTypeOfDocumentationTreeExampleNodes",
         NewType( TheFamilyOfDocumentationTreeNodes,
                 IsTreeForDocumentationExampleNodeRep ) );
 
+DeclareRepresentation( "IsTreeForDocumentationCodeNodeRep",
+                       IsTreeForDocumentationNodeRep,
+                       [ ] );
+
+BindGlobal( "TheTypeOfDocumentationTreeCodeNodes",
+        NewType( TheFamilyOfDocumentationTreeNodes,
+                IsTreeForDocumentationCodeNodeRep ) );
+
 ###################################
 ##
 ## Tools
@@ -251,6 +259,34 @@ InstallMethod( DocumentationDummy, [ IsTreeForDocumentation, IsString ],
                  level := tree!.current_level );
     ObjectifyWithAttributes( node, TheTypeOfDocumentationTreeDummyNodes,
                               Label, name );
+    tree!.nodes_by_label.( name ) := node;
+    return node;
+end );
+
+##
+InstallMethod( DocumentationCode, [ IsTreeForDocumentation, IsString, IsList ],
+  function( tree, name, context )
+    local node;
+    
+    node := DocumentationGroup( tree, name );
+    Add( tree, node, context );
+    return node;
+end );
+
+##
+InstallMethod( DocumentationCode, [ IsTreeForDocumentation, IsString ],
+  function( tree, name )
+    local node;
+    
+    name := Concatenation( "System_", name );
+    if IsBound( tree!.nodes_by_label.( name ) ) then
+        return tree!.nodes_by_label.( name );
+    fi;
+    node := rec( content := [ ],
+                 level := tree!.current_level );
+    
+    ObjectifyWithAttributes( node, TheTypeOfDocumentationTreeCodeNodes,
+                             Label, name );
     tree!.nodes_by_label.( name ) := node;
     return node;
 end );
@@ -588,4 +624,26 @@ InstallMethod( WriteDocumentation, [ IsTreeForDocumentationExampleNodeRep, IsStr
         AppendTo( filestream, i, "\n" );
     od;
     AppendTo( filestream, "]]></", inserted_string, ">\n\n" );
+end );
+
+##
+InstallMethod( WriteDocumentation, [ IsTreeForDocumentationCodeNodeRep, IsStream ],
+  function( node, filestream )
+    local content, i;
+    
+    if node!.level > ValueOption( "level_value" ) then
+        return;
+    fi;
+    
+    content := node!.content;
+    
+    if content = [ ] then
+        return;
+    fi;
+    
+    AppendTo( filestream, "<Listing Type=\"Code\"><![CDATA[\n" );
+    for i in content do
+        AppendTo( filestream, i, "\n" );
+    od;
+    AppendTo( filestream, "]]></Listing>\n" );
 end );


### PR DESCRIPTION
Some more work on the tutorials, specially for those mentioned in #101 