### PR TITLE
Use english month names on title pages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 This file describes changes in the AutoDoc package.
 
+YYY.MM.DD:
+  - Use english month names on title pages
+
 2016.03.08:
   - Fix the "empty index" workaround from the previous release
 

--- a/gap/AutoDocMainFunction.gi
+++ b/gap/AutoDocMainFunction.gi
@@ -211,7 +211,8 @@ end );
 ## seperately.
 InstallGlobalFunction( CreateTitlePage,
   function( dir, argument_rec )
-    local indent, tag, names, filestream, entity_list, OutWithTag, Out, i;
+    local indent, tag, names, filestream, entity_list, OutWithTag, Out, i,
+          months;
 
     filestream := AUTODOC_OutputTextFile( dir, "title.xml" );
     indent := 0;
@@ -258,7 +259,25 @@ InstallGlobalFunction( CreateTitlePage,
         od;
     fi;
 
-    for i in [ "Date", "Address", "Abstract", "Copyright", "Acknowledgements", "Colophon" ] do
+    if IsBound( argument_rec.Date ) then
+        # try to parse the date
+        months := [ "January", "February", "March",
+                    "April", "May", "June",
+                    "July", "August", "September",
+                    "October", "November", "December" ];
+        i := SplitString( argument_rec.Date, "/" );
+        if Length( argument_rec.Date ) in [8..10] and Length( i ) = 3 then
+            OutWithTag( "Date", Concatenation(
+                String( Int( i[1] ) ), " ", # remove leading 0, if any
+                months[Int(i[2])], " ",
+                i[3] ) );
+        else
+            Print("Warning: could not parse package date '", argument_rec.Date, "\n");
+            OutWithTag( "Date", argument_rec.Date );
+        fi;
+    fi;
+
+    for i in [ "Address", "Abstract", "Copyright", "Acknowledgements", "Colophon" ] do
         if IsBound( argument_rec.( i ) ) then
             OutWithTag( i, argument_rec.( i ) );
         fi;


### PR DESCRIPTION
Instead of "01/02/2015" this outputs "1 February 2015", which is less ambiguous.

Of course some people will prefer ""1st February 2015" or even ""February 1st, 2015". Note that the GAP function `Ordinal` would make it quite easy to implement that.

I don't want to provide an option to choose formats, though, let's just pick one (e.g. the one I now used).
