### PR TITLE
Several improvements

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -18,7 +18,7 @@ PackageName := "AutoDoc",
 Subtitle := "Generate documentation from GAP source code",
 
 Version := Maximum( [
-  "2017.06.28", ## Sebas' version
+  "2017.07.07", ## Sebas' version
 ## This line prevents merge conflicts
   "2016.12.04", ## Max' version
 ## This line prevents merge conflicts

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -18,7 +18,7 @@ PackageName := "AutoDoc",
 Subtitle := "Generate documentation from GAP source code",
 
 Version := Maximum( [
-  "2017.07.07", ## Sebas' version
+  "2017.08.03", ## Sebas' version
 ## This line prevents merge conflicts
   "2016.12.04", ## Max' version
 ## This line prevents merge conflicts

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -18,7 +18,7 @@ PackageName := "AutoDoc",
 Subtitle := "Generate documentation from GAP source code",
 
 Version := Maximum( [
-  "2017.01.16", ## Sebas' version
+  "2017.06.28", ## Sebas' version
 ## This line prevents merge conflicts
   "2016.12.04", ## Max' version
 ## This line prevents merge conflicts

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -138,6 +138,7 @@ text in your documentation, examples, mathematical chapters, etc..
 
 <Subsection Label="@Chapter">
 <Index Key="@Chapter"><C>@Chapter</C></Index>
+<Index Key="@ChapterLabel"><C>@ChapterLabel</C></Index>
 <Heading>@Chapter <A>name</A></Heading>
 Sets a chapter, all functions without separate info will be added to this chapter.
 Also all text comments, i.e. lines that begin with #! without a command, and which do not
@@ -150,10 +151,18 @@ Example:
 #!  This is my chapter.
 #!  I document my stuff in it.
 ]]></Listing>
+
+The <C>@ChapterLabel</C> <A>label</A> command
+can be used to set the label of the chapter to <C>Chapter_</C><A>label</A>.
+
+Additionally, the chapter will be stored as <C>_Chapter_</C><A>label</A><C>.xml</C>.
+
+
 </Subsection>
 
 <Subsection Label="@Section">
 <Index Key="@Section"><C>@Section</C></Index>
+<Index Key="@SectionLabel"><C>@SectionLabel</C></Index>
 <Heading>@Section <A>name</A></Heading>
 Sets a section like chapter sets a chapter.
 
@@ -161,6 +170,9 @@ Sets a section like chapter sets a chapter.
 #! @Section My first manual section
 #!  In this section I am going to document my first method.
 ]]></Listing>
+
+The <C>@SectionLabel</C> <A>label</A> command
+can be used to set the label of the section to <C>Section_</C><A>label</A>.
 </Subsection>
 
 <Subsection Label="@EndSection">
@@ -178,6 +190,7 @@ opening it might cause unexpected errors.
 
 <Subsection Label="@Subsection">
 <Index Key="@Subsection"><C>@Subsection</C></Index>
+<Index Key="@SubsectionLabel"><C>@SubsectionLabel</C></Index>
 <Heading>@Subsection <A>name</A></Heading>
 Sets a subsection like chapter sets a chapter.
 
@@ -185,6 +198,10 @@ Sets a subsection like chapter sets a chapter.
 #! @Subsection My first manual subsection
 #!  In this subsection I am going to document my first example.
 ]]></Listing>
+
+The <C>@SubsectionLabel</C> <A>label</A> command
+can be used to set the label of the subsection to <C>Subsection_</C><A>label</A>.
+
 </Subsection>
 
 <Subsection Label="@EndSubsection">

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -314,11 +314,49 @@ Order(S5);
 ]]></Listing>
 </Subsection>
 
+
+<Subsection Label="@ExampleSession">
+<Index Key="@ExampleSession"><C>@ExampleSession, @BeginExampleSession, and @EndExampleSession</C></Index>
+<Heading>@ExampleSession and @EndExampleSession</Heading>
+@ExampleSession inserts an example into the manual, but in a different syntax.
+For example, consider
+<Listing><![CDATA[
+#! @BeginExample
+S5 := SymmetricGroup(5);
+#! Sym( [ 1 .. 5 ] )
+Order(S5);
+#! 120
+#! @EndExample
+]]></Listing>
+As you can see, the commands are not commented and hence are executed when the file containing
+the example block is read. To insert examples directly into source code files, one can instead
+use @ExampleSession:
+<Listing><![CDATA[
+#! @ExampleSession
+#! gap> S5 := SymmetricGroup(5);
+#! Sym( [ 1 .. 5 ] )
+#! gap> Order(S5);
+#! 120
+#! @EndExampleSession
+]]></Listing>
+It inserts an example into the manual just as @Example would do, but all lines are commented
+and therefore not executed when the file is read.
+</Subsection>
+
+
+
 <Subsection Label="@BeginLog">
 <Index Key="@BeginLog"><C>@BeginLog and @EndLog</C></Index>
 <Heading>@BeginLog and @EndLog</Heading>
 Works just like the @BeginExample command, but the example
 will not be tested. See the GAPDoc manual for more information.
+</Subsection>
+
+<Subsection Label="@BeginLogSession">
+<Index Key="@BeginLogSession"><C>@BeginLogSession and @EndLogSession</C></Index>
+<Heading>@BeginLogSession and @EndLogSession</Heading>
+Works just like the @BeginExampleSession command, but the example
+will not be tested if manual examples are run. See the GAPDoc manual for more information.
 </Subsection>
 
 <Subsection Label="@DoNotReadRestOfFile">

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -300,9 +300,11 @@ Resets the current level to 0.
 <Subsection Label="@BeginExample">
 <Index Key="@BeginExample"><C>@BeginExample and @EndExample</C></Index>
 <Heading>@BeginExample and @EndExample</Heading>
-@BeginExample inserts an example into the manual. The syntax is like the example environment
-in GAPDoc. This examples can be tested by GAPDoc, and also stay readable by GAP.
-The GAP prompt is added by AutoDoc.
+@BeginExample inserts an example into the manual. The syntax for examples is different from
+GAPDocs example syntax in order to have a
+file that contains the example and is GAP readable. To achieve this, GAP commands are not preceded by a comment,
+while output has to be preceded by an &AutoDoc; comment.
+The GAP prompt for the display in the manual is added by AutoDoc.
 @EndExample ends the example block.
 <Listing><![CDATA[
 #! @BeginExample

--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -478,7 +478,7 @@ end );
 ##
 InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForChapterRep, IsStream, IsDirectory ],
   function( node, stream, path_to_xmlfiles )
-    local filename, chapter_stream, label, replaced_name;
+    local filename, chapter_stream, label, replaced_name, additional_label;
 
     if node!.level > ValueOption( "level_value" ) then
         return;
@@ -487,16 +487,21 @@ InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForChapterRep, Is
         return;
     fi;
     label := Label( node );
+    if IsBound( node!.additional_label ) then
+        additional_label := node!.additional_label;
+    else
+        additional_label := label;
+    fi;
 
     # Remove any characters outside of A-Za-z0-9 and -, +, _ from the filename.
     # See issues #77 and #78
-    filename := Filtered(label, x -> x in AUTODOC_IdentifierLetters);
+    filename := Filtered( additional_label, x -> x in AUTODOC_IdentifierLetters);
     filename := Concatenation( "_", filename, ".xml" );
 
     chapter_stream := AUTODOC_OutputTextFile( path_to_xmlfiles, filename );
     AppendTo( stream, "<#Include SYSTEM \"", filename, "\">\n" );
     AppendTo( chapter_stream, AUTODOC_XML_HEADER );
-    AppendTo( chapter_stream, "<Chapter Label=\"", label,"\">\n" );
+    AppendTo( chapter_stream, "<Chapter Label=\"", additional_label ,"\">\n" );
     replaced_name := ReplacedString( node!.name, "_", " " );
     AppendTo( chapter_stream, Concatenation( [ "<Heading>", replaced_name, "</Heading>\n\n" ] ) );
     WriteDocumentation( node!.content, chapter_stream );
@@ -546,7 +551,7 @@ end );
 ##
 InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForSectionRep, IsStream ],
   function( node, filestream )
-    local replaced_name;
+    local replaced_name, label, additional_label;
 
     if node!.level > ValueOption( "level_value" ) then
         return;
@@ -554,7 +559,12 @@ InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForSectionRep, Is
     if ForAll( node!.content, IsEmptyNode ) then
         return;
     fi;
-    AppendTo( filestream, "<Section Label=\"", Label( node ), "\">\n" );
+    if IsBound( node!.additional_label ) then
+        label := node!.additional_label;
+    else
+        label := Label( node );;
+    fi;
+    AppendTo( filestream, "<Section Label=\"", label, "\">\n" );
     replaced_name := ReplacedString( node!.name, "_", " " );
     AppendTo( filestream, Concatenation( [ "<Heading>", replaced_name, "</Heading>\n\n" ] ) );
     WriteDocumentation( node!.content, filestream );
@@ -564,7 +574,7 @@ end );
 ##
 InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForSubsectionRep, IsStream ],
   function( node, filestream )
-    local replaced_name;
+    local replaced_name, label, additional_label;
 
     if node!.level > ValueOption( "level_value" ) then
         return;
@@ -572,7 +582,12 @@ InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForSubsectionRep,
     if ForAll( node!.content, IsEmptyNode ) then
         return;
     fi;
-    AppendTo( filestream, "<Subsection Label=\"", Label( node ), "\">\n" );
+    if IsBound( node!.additional_label ) then
+        label := node!.additional_label;
+    else
+        label := Label( node );
+    fi;
+    AppendTo( filestream, "<Subsection Label=\"", label, "\">\n" );
     replaced_name := ReplacedString( node!.name, "_", " " );
     AppendTo( filestream, Concatenation( [ "<Heading>", replaced_name, "</Heading>\n\n" ] ) );
     WriteDocumentation( node!.content, filestream );

--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -279,14 +279,17 @@ InstallMethod( DocumentationCode, [ IsTreeForDocumentation, IsString ],
     local node;
     
     name := Concatenation( "System_", name );
-    if IsBound( tree!.nodes_by_label.( name ) ) then
-        return tree!.nodes_by_label.( name );
-    fi;
+    
     node := rec( content := [ ],
                  level := tree!.current_level );
     
     ObjectifyWithAttributes( node, TheTypeOfDocumentationTreeCodeNodes,
                              Label, name );
+    
+    if IsBound( tree!.nodes_by_label.( name ) ) then
+        Add( tree!.nodes_by_label.( name )!.content, node );
+    fi;
+    
     tree!.nodes_by_label.( name ) := node;
     return node;
 end );

--- a/gap/Markdown.gi
+++ b/gap/Markdown.gi
@@ -25,13 +25,22 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
   function( string_list )
     local i, current_list, current_string, max_line_length,
           current_position, already_in_list, command_list_with_translation, beginning,
-          commands, position_of_command, insert, beginning_whitespaces, temp, string_list_temp, skipped;
+          commands, position_of_command, insert, beginning_whitespaces, temp, string_list_temp, skipped,
+          already_inserted_paragraph;
 
-    ## Check for paragraphs by making an empty string into <br/>
-    for i in [ 2 .. Length( string_list ) - 1 ] do
-        if string_list[ i ] = "" then
-            string_list[ i ] := "<Br/>";
+    ## Check for paragraphs by turning an empty string into <P/>
+    
+    already_inserted_paragraph := false;
+    for i in [ 1 ..  Length( string_list ) ] do
+        if NormalizedWhitespace( string_list[ i ] ) = "" then
+            if already_inserted_paragraph = false then
+                string_list[ i ] := "<P/>";
+                already_inserted_paragraph := true;
+            fi;
+        else
+            already_inserted_paragraph := false;
         fi;
+        i := i + 1;
     od;
 
     ## We need to find lists. Lists are indicated by a beginning

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -249,6 +249,9 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                 if current_item!.tester_names = fail and StripBeginEnd( filter_string, " " ) <> "for" then
                     current_item!.tester_names := filter_string;
                 fi;
+                if StripBeginEnd( filter_string, " " ) = "for" then
+                    has_filters := "empty_argument_list";
+                fi;
                 ##Adjust arguments
                 if not IsBound( current_item!.arguments ) then
                     if IsInt( has_filters ) then
@@ -264,6 +267,8 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                         else
                             current_item!.arguments := JoinStringsWithSeparator( current_item!.arguments, "," );
                         fi;
+                    elif has_filters = "empty_argument_list" then
+                        current_item!.arguments := "";
                     fi;
                 fi;
             fi;

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -61,6 +61,13 @@ InstallGlobalFunction( AutoDoc_Type_Of_Item,
     elif PositionSublist( type, "DeclareOperation" ) <> fail then
         entries := [ "Oper", "methods" ];
         has_filters := "List";
+    elif PositionSublist( type, "DeclareConstructor" ) <> fail then
+        ## FIXME: there should be a Constructor tag, but it is unfortunately not possible, since GAPDoc
+        ##        does not offer such a tag. Issue for this is filed here:
+        ##        https://github.com/frankluebeck/GAPDoc/issues/23
+        ##        Once this is fixed, the next line needs to be changed accordingly.
+        entries := [ "Oper", "methods" ];
+        has_filters := "List";
     elif PositionSublist( type, "DeclareGlobalFunction" ) <> fail then
         entries := [ "Func", "global_functions" ];
         has_filters := "No";

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -625,7 +625,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         @Log := ~.@BeginLog,
         STRING := function()
             local comment_pos;
-            if not IsBound( current_item ) or current_command[ 2 ] = "" then
+            if not IsBound( current_item ) then
                 return;
             fi;
             comment_pos := PositionSublist( current_line_unedited, "#!" );

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -439,6 +439,15 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             current_item := ChapterInTree( tree, scope_chapter );
             chapter_info[ 1 ] := scope_chapter;
         end,
+        @ChapterLabel := function()
+            local scope_chapter, label_name;
+            if not IsBound( chapter_info[ 1 ] ) then
+                ErrorWithPos( "found @ChapterLabel with no active chapter" );
+            fi;
+            label_name := ReplacedString( current_command[ 2 ], " ", "_" );
+            scope_chapter := ChapterInTree( tree, chapter_info[ 1 ] );
+            scope_chapter!.additional_label := Concatenation( "Chapter_", label_name );
+        end,
         @Section := function()
             local scope_section;
             if not IsBound( chapter_info[ 1 ] ) then
@@ -448,6 +457,15 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             current_item := SectionInTree( tree, chapter_info[ 1 ], scope_section );
             Unbind( chapter_info[ 3 ] );
             chapter_info[ 2 ] := scope_section;
+        end,
+        @SectionLabel := function()
+            local scope_section, label_name;
+            if not IsBound( chapter_info[ 2 ] ) then
+                ErrorWithPos( "found @SectionLabel with no active section" );
+            fi;
+            label_name := ReplacedString( current_command[ 2 ], " ", "_" );
+            scope_section := SectionInTree( tree, chapter_info[ 1 ], chapter_info[ 2 ] );
+            scope_section!.additional_label := Concatenation( "Section_", label_name );
         end,
         @EndSection := function()
             Unbind( chapter_info[ 2 ] );
@@ -462,6 +480,15 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             scope_subsection := ReplacedString( current_command[ 2 ], " ", "_" );
             current_item := SubsectionInTree( tree, chapter_info[ 1 ], chapter_info[ 2 ], scope_subsection );
             chapter_info[ 3 ] := scope_subsection;
+        end,
+        @SubsectionLabel := function()
+            local scope_subsection, label_name;
+            if not IsBound( chapter_info[ 3 ] ) then
+                ErrorWithPos( "found @SubsectionLabel with no active Subsection" );
+            fi;
+            label_name := ReplacedString( current_command[ 2 ], " ", "_" );
+            scope_subsection := SubsectionInTree( tree, chapter_info[ 1 ], chapter_info[ 2 ], chapter_info[ 3 ] );
+            scope_subsection!.additional_label := Concatenation( "Subsection_", label_name );
         end,
         @EndSubsection := function()
             Unbind( chapter_info[ 3 ] );

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -246,7 +246,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                 filter_string := ReplacedString( filter_string, "\"", "" );
             fi;
             if filter_string <> false then
-                if current_item!.tester_names = fail then
+                if current_item!.tester_names = fail and StripBeginEnd( filter_string, " " ) <> "for" then
                     current_item!.tester_names := filter_string;
                 fi;
                 ##Adjust arguments

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -116,7 +116,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
           context_stack, new_man_item, add_man_item, Reset, read_code, title_item, title_item_list, plain_text_mode,
           current_line_unedited,
           ReadLineWithLineCount, Normalized_ReadLine, line_number, ErrorWithPos, create_title_item_function,
-          current_line_positition_for_filter;
+          current_line_positition_for_filter, read_session_example;
     groupnumber := 0;
     level_scope := 0;
     autodoc_read_line := false;
@@ -415,6 +415,33 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         od;
         return example_node;
     end;
+    read_session_example := function( is_tested_example )
+        local temp_string_list, temp_curr_line, temp_pos_comment, is_following_line, item_temp, example_node;
+        example_node := DocumentationExample( tree );
+        if is_tested_example = false then
+            example_node!.is_tested_example := false;
+        else
+            example_node!.is_tested_example := true;
+        fi;
+        temp_string_list := example_node!.content;
+        while true do
+            temp_curr_line := ReadLineWithLineCount( filestream );
+            if temp_curr_line[ Length( temp_curr_line )] = '\n' then
+                temp_curr_line := temp_curr_line{[ 1 .. Length( temp_curr_line ) - 1 ]};
+            fi;
+            if filestream = fail or PositionSublist( temp_curr_line, "@EndExampleSession" ) <> fail
+                                 or PositionSublist( temp_curr_line, "@EndLogSession" ) <> fail then
+                break;
+            fi;
+            #! @DONT_SCAN_NEXT_LINE
+            temp_pos_comment := PositionSublist( temp_curr_line, "#!" );
+            if temp_pos_comment <> fail then
+                temp_curr_line := temp_curr_line{[ temp_pos_comment + 2 .. Length( temp_curr_line ) ]};
+                Add( temp_string_list, temp_curr_line );
+            fi;
+        od;
+        return example_node;
+    end;
     command_function_record := rec(
         ## HACK: Needed for AutoDoc parser to be scanned savely.
         ##       The lines where the AutoDoc comments are
@@ -638,6 +665,18 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         @EndAutoDocPlainText := function()
             plain_text_mode := false;
         end,
+        @ExampleSession := function()
+            local example_node;
+            example_node := read_session_example( true );
+            Add( current_item, example_node );
+        end,
+        @BeginExampleSession := ~.@ExampleSession,
+        @LogSession := function()
+            local example_node;
+            example_node := read_session_example( false );
+            Add( current_item, example_node );
+        end,
+        @BeginLogSession := ~.@LogSession
     );
     
     ## The following commands are specific for worksheets. They do not have a packageinfo,

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -42,7 +42,7 @@ InstallGlobalFunction( AutoDoc_WriteDocEntry,
     od;
 
     if not IsBound( return_value ) then
-        return_value := "";
+        return_value := false;
     fi;
 
     if IsList( return_value ) and ( not IsString( return_value ) ) and return_value <> "" then


### PR DESCRIPTION
* Correct scanning of ´KeyDependendOperation`
* No label for functions with no filters
* No argument for functions with no argument
* Documentation of `DeclareConstructor`
* No return statement printed if no `@Returns` is given
* ChapterLabel, SectionLabel, SubsectionLabel
* Listing for GAPDoc example style
* Fixup of example doc