### PR TITLE
Spacing in new @ExampleSession environment:

### DIFF
--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -343,6 +343,12 @@ use @ExampleSession:
 ]]></Listing>
 It inserts an example into the manual just as @Example would do, but all lines are commented
 and therefore not executed when the file is read.
+All lines that should be part of the example displayed in the manual
+have to start with an &AutoDoc; comment (<C>#!</C>).
+The comment will be removed, and, if the following character is a space,
+this space will also be removed. There is never more than one space removed.
+To ensure examples are correctly colored in the manual, 
+there should be exactly one space between <C>#!</C> and the <C>gap</C> prompt.
 </Subsection>
 
 

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -437,6 +437,9 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             temp_pos_comment := PositionSublist( temp_curr_line, "#!" );
             if temp_pos_comment <> fail then
                 temp_curr_line := temp_curr_line{[ temp_pos_comment + 2 .. Length( temp_curr_line ) ]};
+                if Length( temp_curr_line ) >= 1 and temp_curr_line[ 1 ] = ' ' then
+                    Remove( temp_curr_line, 1 );
+                fi;
                 Add( temp_string_list, temp_curr_line );
             fi;
         od;


### PR DESCRIPTION
Since GAPDoc only highlights the examples properly if there is no space in front
of the gap> prompt, the standard is now that one character after the AutoDoc comments is
removed.