### PR TITLE
Make copy of string before printing string,

### DIFF
--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -518,7 +518,7 @@ InstallMethod( WriteDocumentation, [ IsList, IsStream ],
     current_string_list := [ ];
     for i in [ 1 .. Length( node_list ) ] do
         if IsString( node_list[ i ] ) then
-            Add( current_string_list, node_list[ i ] );
+            Add( current_string_list, ShallowCopy( node_list[ i ] ) );
         else
             if current_string_list <> [ ] then
                 current_string_list := CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML( current_string_list );
@@ -541,7 +541,7 @@ InstallMethod( WriteDocumentation, [ IsString, IsStream ],
     ## In case the list is empty, do nothing.
     ## Once the empty string = empty list bug is fixed,
     ## this could be removed.
-    NormalizeWhitespace( text );
+    text := NormalizedWhitespace( text );
     if text = "" then
         return;
     fi;


### PR DESCRIPTION
and do not use in-place NormalizeWhitespace in printing of string
since normalizing the string can cause markdown parser to fail the
second time a chunk is inserted. Closes #141.