### PR TITLE
Consistent documentation

### DIFF
--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -341,9 +341,9 @@ Order(S5);
 </Subsection>
 
 
-<Subsection Label="@ExampleSession">
-<Index Key="@ExampleSession"><C>@ExampleSession, @BeginExampleSession, and @EndExampleSession</C></Index>
-<Heading>@ExampleSession and @EndExampleSession</Heading>
+<Subsection Label="@BeginExampleSession">
+<Index Key="@BeginExampleSession"><C>@BeginExampleSession and @EndExampleSession</C></Index>
+<Heading>@BeginExampleSession and @EndExampleSession</Heading>
 @ExampleSession inserts an example into the manual, but in a different syntax.
 For example, consider
 <Listing><![CDATA[
@@ -358,7 +358,7 @@ As you can see, the commands are not commented and hence are executed when the f
 the example block is read. To insert examples directly into source code files, one can instead
 use @ExampleSession:
 <Listing><![CDATA[
-#! @ExampleSession
+#! @BeginExampleSession
 #! gap> S5 := SymmetricGroup(5);
 #! Sym( [ 1 .. 5 ] )
 #! gap> Order(S5);

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -338,6 +338,7 @@ Order(S5);
 #! 120
 #! @EndExample
 ]]></Listing>
+The &AutoDoc; command <C>@Example</C> is an alias of <C>@BeginExample</C>.
 </Subsection>
 
 
@@ -373,6 +374,7 @@ The comment will be removed, and, if the following character is a space,
 this space will also be removed. There is never more than one space removed.
 To ensure examples are correctly colored in the manual, 
 there should be exactly one space between <C>#!</C> and the <C>gap</C> prompt.
+The &AutoDoc; command <C>@ExampleSession</C> is an alias of <C>@BeginExampleSession</C>.
 </Subsection>
 
 
@@ -382,6 +384,7 @@ there should be exactly one space between <C>#!</C> and the <C>gap</C> prompt.
 <Heading>@BeginLog and @EndLog</Heading>
 Works just like the @BeginExample command, but the example
 will not be tested. See the GAPDoc manual for more information.
+The &AutoDoc; command <C>@Log</C> is an alias of <C>@BeginLog</C>.
 </Subsection>
 
 <Subsection Label="@BeginLogSession">
@@ -389,6 +392,7 @@ will not be tested. See the GAPDoc manual for more information.
 <Heading>@BeginLogSession and @EndLogSession</Heading>
 Works just like the @BeginExampleSession command, but the example
 will not be tested if manual examples are run. See the GAPDoc manual for more information.
+The &AutoDoc; command <C>@LogSession</C> is an alias of <C>@BeginLogSession</C>.
 </Subsection>
 
 <Subsection Label="@DoNotReadRestOfFile">


### PR DESCRIPTION
Fixed inconsistencies in documentation:
* Documented `@BeginExampleSession` instead of `@ExampleSession`
* Documented aliases `@Example`, `@Log`, `@ExampleSession`, and `@LogSession`