### PR TITLE
 Handle documentation of DeclareCategoryCollection declarations. 

### DIFF
--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -14,6 +14,54 @@ gap> Size(S5);
 
 
 And we wrap up with some dummy text
+<Section Label="Chapter_SomeChapter_Section_Some_categories">
+<Heading>Some categories</Heading>
+
+Intro text
+<ManSection>
+  <Filt Arg="arg" Name="MyThings" Label="for IsObject"/>
+ <Returns><C>true</C> or <C>false</C>
+</Returns>
+ <Description>
+<P/>
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Filt Arg="obj" Name="MyThingsCollection" />
+ <Returns><C>true</C> or <C>false</C>
+</Returns>
+ <Description>
+<P/>
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Filt Arg="obj" Name="MyThingsCollColl" />
+ <Returns><C>true</C> or <C>false</C>
+</Returns>
+ <Description>
+<P/>
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Filt Arg="obj" Name="MyThingsCollColl" />
+ <Returns><C>true</C> or <C>false</C>
+</Returns>
+ <Description>
+<P/>
+ </Description>
+</ManSection>
+
+
+Let's wrap up with something, though.
+</Section>
+
+
 <Section Label="Chapter_SomeChapter_Section_SomeSection">
 <Heading>SomeSection</Heading>
 

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -22,6 +22,16 @@ Print( "(Even though we never use it that way.\n" );
 #! @EndExampleSession
 #! And we wrap up with some dummy text
 
+#! @Section Some categories
+#!  Intro text
+DeclareCategory("MyThings", IsObject);
+DeclareCategoryCollections("MyThings");
+DeclareCategoryCollections("MyThingsColl");
+DeclareCategoryCollections("MyThingsCollection");
+Now here is some text with a bunch of &!$%*!/ weird things in it. But that
+should be OK, nothing should end up in a weird place.
+#! Let's wrap up with something, though.
+
 #! @Section SomeSection
 
 #! Some test just inside a section. We can use test some markdown features here:


### PR DESCRIPTION
Note that AutoDoc here duplicates logic in `gap/lib/coll.gd` to determine the
actual name of the symbol being defined by the call (since that symbol is
computed on the fly by the declaration and does not appear verbatim anywhere
in the call). This is unfortunate, but I could not see any way to call the
relevant code in the standard library, as the name computation of the
collections category is not split out into a separately executable function.

Also, modify the `worksheet.tst` to include an example of
`DeclareCategoryCollection` to make sure the new capacity is tested.

Note that this pull request is on top of the changes made for pull request #166, because otherwise I wasn't sure how to ensure that this pull request included test for the new facility; I just needed to be on top of a test harness.

Resolves: #170