### PR TITLE
Make @Begin.../@EndExampleSession respect plain_text_mode

### DIFF
--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -474,14 +474,12 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         od;
         return example_node;
     end;
-    read_session_example := function( is_tested_example )
-        local temp_string_list, temp_curr_line, temp_pos_comment, is_following_line, item_temp, example_node;
+    read_session_example := function( is_tested_example, plain_text_mode )
+        local temp_string_list, temp_curr_line, temp_pos_comment,
+              is_following_line, item_temp, example_node,
+              incorporate_this_line;
         example_node := DocumentationExample( tree );
-        if is_tested_example = false then
-            example_node!.is_tested_example := false;
-        else
-            example_node!.is_tested_example := true;
-        fi;
+        example_node!.is_tested_example := is_tested_example;
         temp_string_list := example_node!.content;
         while true do
             temp_curr_line := ReadLineWithLineCount( filestream );
@@ -492,13 +490,19 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                                  or PositionSublist( temp_curr_line, "@EndLogSession" ) <> fail then
                 break;
             fi;
-            #! @DONT_SCAN_NEXT_LINE
-            temp_pos_comment := PositionSublist( temp_curr_line, "#!" );
-            if temp_pos_comment <> fail then
-                temp_curr_line := temp_curr_line{[ temp_pos_comment + 2 .. Length( temp_curr_line ) ]};
-                if Length( temp_curr_line ) >= 1 and temp_curr_line[ 1 ] = ' ' then
-                    Remove( temp_curr_line, 1 );
+            incorporate_this_line := plain_text_mode;
+            if not plain_text_mode then
+                #! @DONT_SCAN_NEXT_LINE
+                temp_pos_comment := PositionSublist( temp_curr_line, "#!" );
+                if temp_pos_comment <> fail then
+                    incorporate_this_line := true;
+                    temp_curr_line := temp_curr_line{[ temp_pos_comment + 2 .. Length( temp_curr_line ) ]};
+                    if Length( temp_curr_line ) >= 1 and temp_curr_line[ 1 ] = ' ' then
+                        Remove( temp_curr_line, 1 );
+                    fi;
                 fi;
+            fi;
+            if incorporate_this_line then
                 Add( temp_string_list, temp_curr_line );
             fi;
         od;
@@ -806,13 +810,13 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         end,
         @ExampleSession := function()
             local example_node;
-            example_node := read_session_example( true );
+            example_node := read_session_example( true, plain_text_mode );
             Add( current_item, example_node );
         end,
         @BeginExampleSession := ~.@ExampleSession,
         @LogSession := function()
             local example_node;
-            example_node := read_session_example( false );
+            example_node := read_session_example( false, plain_text_mode );
             Add( current_item, example_node );
         end,
         @BeginLogSession := ~.@LogSession

--- a/tst/worksheets.tst
+++ b/tst/worksheets.tst
@@ -10,4 +10,16 @@ Extracting manual examples for General Test package ...
 Chapter 1 : extracted 1 examples
 
 #
+gap> AUTODOC_TestWorkSheet("autoplain");
+Extracting manual examples for Plain file.autodoc Test package ...
+1 chapters detected
+Chapter 1 : extracted 1 examples
+
+#
+gap> AUTODOC_TestWorkSheet("plain");
+Extracting manual examples for Plain Text Mode Test package ...
+1 chapters detected
+Chapter 1 : extracted 1 examples
+
+#
 gap> STOP_TEST( "worksheets.tst" );

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- This is an automatically generated file. -->
+<Chapter Label="Chapter_Test">
+<Heading>Test</Heading>
+
+#############################################################################
+##
+## AutoDoc package
+##
+## Test the behavior of AutoDoc on a .autodoc file
+##
+#############################################################################
+Does AutoDoc have a way to allow that header block not to appear in
+the documentation generated from a <F>.autodoc</F> file like this?
+<Example><![CDATA[
+gap> S5 := SymmetricGroup(5);
+Sym( [ 1 .. 5 ] )
+gap> Size(S5);
+120
+]]></Example>
+
+
+And we wrap up with some dummy text
+</Chapter>
+

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -1,0 +1,22 @@
+@Chapter Test
+#############################################################################
+##
+##  AutoDoc package
+##
+##  Test the behavior of AutoDoc on a .autodoc file
+##
+#############################################################################
+@Title Plain file.autodoc Test
+@Date 30/08/2018
+@Chapter Test
+Does AutoDoc have a way to allow that header block not to appear in
+the documentation generated from a <F>.autodoc</F> file like this?
+@BeginExampleSession
+gap> S5 := SymmetricGroup(5);
+Sym( [ 1 .. 5 ] )
+gap> Size(S5);
+120
+@EndExampleSession
+And we wrap up with some dummy text
+@EndAutoDocPlainText
+Print( "We can switch back to 'regular' mode even in a .autodoc file.\n" );

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -2,11 +2,6 @@
 ##
 ##  AutoDoc package
 ##
-##  Copyright 2018
-##    Contributed by Glen Whitney, studioinfinity.org
-##
-##  Licensed under the GPL 2 or later.
-##
 #############################################################################
 Print( "Pretend this is a code file.\n" );
 Print( "(Even though we never use it that way.\n" );

--- a/tst/worksheets/plain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/plain.expected/_Chapter_Test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- This is an automatically generated file. -->
+<Chapter Label="Chapter_Test">
+<Heading>Test</Heading>
+
+This is dummy text
+<Example><![CDATA[
+gap> S5 := SymmetricGroup(5);
+Sym( [ 1 .. 5 ] )
+gap> Size(S5);
+120
+]]></Example>
+
+
+And we wrap up with some dummy text
+But this should produce more text.
+</Chapter>
+

--- a/tst/worksheets/plain.sheet/plain.g
+++ b/tst/worksheets/plain.sheet/plain.g
@@ -1,0 +1,24 @@
+#############################################################################
+##
+##  AutoDoc package
+##
+##  Test the behavior of AutoDoc in plain text mode
+##
+#############################################################################
+Print( "Pretend this is a code file.\n" );
+Print( "(Even though we never use it that way.)\n" );
+#! @Title Plain Text Mode Test
+#! @Date 30/08/2018
+#! @AutoDocPlainText
+@Chapter Test
+This is dummy text
+@BeginExampleSession
+gap> S5 := SymmetricGroup(5);
+Sym( [ 1 .. 5 ] )
+gap> Size(S5);
+120
+@EndExampleSession
+And we wrap up with some dummy text
+@EndAutoDocPlainText
+Print( "This line in the file should not be processed.\n" );
+#! But this should produce more text.


### PR DESCRIPTION
In order to uniformize the handling of #! prefixes in AutoDoc files,
gap/Parser.gi is changed to pass lines between @BeginExampleSession and
@EndExampleSession through unchanged when plain_text_mode is true.

Note this commit also supplies two test worksheets. They will not have any
effect unless/until the test harness supplied with pull request #180 is put in
place. But the worksheets do at least serve as illustrations of the intended
behavior post this change, and should otherwise be innocuous.

Resolves #167 

This replaces pull request #168, which I will now close.