### PR TITLE
Added possibility to mark function arguments via {A}

### DIFF
--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -739,6 +739,21 @@ can be important.</E>
 
 </Subsection>
 
+ <Subsection Label="MarkdownExtensionArgument">
+   <Heading>Function arguments</Heading>
+
+   One can mark function parameters by using curly braces ({}) at the
+   beginning and the end of the text which should be marked as a parameter. Example:
+
+<Listing><![CDATA[
+#! The function takes one parameter {a}
+]]></Listing>
+
+    This produces the following output:<Br/>
+    The function takes one parameter <A>a</A>
+
+</Subsection>
+
 </Section>
 
 </Chapter>

--- a/gap/Markdown.gi
+++ b/gap/Markdown.gi
@@ -26,7 +26,7 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
     local i, current_list, current_string, max_line_length,
           current_position, already_in_list, command_list_with_translation, beginning,
           commands, position_of_command, insert, beginning_whitespaces, temp, string_list_temp, skipped,
-          already_inserted_paragraph, in_list, in_item;
+          already_inserted_paragraph, in_list, in_item, index_for_command;
 
     ## Check for paragraphs by turning an empty string into <P/>
     
@@ -141,16 +141,18 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
     od;
 
     ## Find commands
-    command_list_with_translation := [ [ "$$", "Display" ],
-                                       [ "$", "Math" ],
-                                       [ "`", "Code" ],
-                                       [ "**", "Emph" ],
-                                       [ "__", "Emph" ] ];
+    command_list_with_translation := [ [ [ "$$", "$$" ], "Display" ],
+                                       [ [ "$", "$", ], "Math" ],
+                                       [ [ "`", "`" ], "Code" ],
+                                       [ [ "**", "**" ], "Emph" ],
+                                       [ [ "__", "__" ], "Emph" ],
+                                       [ [ "{", "}" ], "A"] ];
     ## special handling for \$
     for i in [ 1 .. Length( string_list ) ] do
         string_list[ i ] := ReplacedString( string_list[ i ], "\\$", "&#36;" );
     od;
 
+    index_for_command := 1;
     for commands in command_list_with_translation do
         beginning := true;
         skipped := false;
@@ -165,15 +167,20 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
                 continue;
             fi;
 
-            while PositionSublist( string_list[ i ], commands[ 1 ] ) <> fail do
-                position_of_command := PositionSublist( string_list[ i ], commands[ 1 ] );
+            while PositionSublist( string_list[ i ], commands[ 1 ][ index_for_command ] ) <> fail do
+                position_of_command := PositionSublist( string_list[ i ], commands[ 1 ][ index_for_command ] );
                 if beginning = true then
                     insert := Concatenation( "<", commands[ 2 ], ">" );
                 else
                     insert := Concatenation( "</", commands[ 2 ], ">" );
                 fi;
-                string_list[ i ] := INSERT_IN_STRING_WITH_REPLACE( string_list[ i ], insert, position_of_command, Length( commands[ 1 ] ) );
+                string_list[ i ] := INSERT_IN_STRING_WITH_REPLACE( string_list[ i ], insert, position_of_command, Length( commands[ 1 ][ index_for_command ] ) );
                 beginning := not beginning;
+                if index_for_command = 1 then
+                    index_for_command := 2;
+                else
+                    index_for_command := 1;
+                fi;
             od;
         od;
 

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -39,6 +39,9 @@ This is also <Emph>emphasized</Emph> text in a list item.
 <Item>
 This is <Code>inline code</Code> in a list item.
 </Item>
+<Item>
+<A>A</A> is an argument.
+</Item>
 </List>
 <P/>
 All of this can <Emph>also</Emph> be <Emph>used</Emph> outside of a <Code>list</Code>.

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -31,6 +31,7 @@ Print( "(Even though we never use it that way.\n" );
 #! * This is __emphasized__ text in a list item.
 #! * This is also **emphasized** text in a list item.
 #! * This is `inline code` in a list item.
+#! * {A} is an argument.
 #!
 #! All of this can **also** be __used__ outside of a `list`.
 


### PR DESCRIPTION
And, on the way, make markdown support different markers
for beginning and end of a tag