### PR TITLE
Add AUTODOC_FormatDate helper

### DIFF
--- a/gap/AutoDocMainFunction.gi
+++ b/gap/AutoDocMainFunction.gi
@@ -225,8 +225,7 @@ end );
 ## separately.
 InstallGlobalFunction( CreateTitlePage,
   function( dir, argument_rec )
-    local indent, tag, names, filestream, entity_list, OutWithTag, Out, i,
-          months;
+    local indent, tag, names, filestream, entity_list, OutWithTag, Out, i;
 
     filestream := AUTODOC_OutputTextFile( dir, "title.xml" );
     indent := 0;
@@ -274,17 +273,11 @@ InstallGlobalFunction( CreateTitlePage,
     fi;
 
     if IsBound( argument_rec.Date ) then
-        # try to parse the date
-        months := [ "January", "February", "March",
-                    "April", "May", "June",
-                    "July", "August", "September",
-                    "October", "November", "December" ];
+        # try to parse the date in format DD/MM/YYYY
         i := SplitString( argument_rec.Date, "/" );
         if Length( argument_rec.Date ) in [8..10] and Length( i ) = 3 then
-            OutWithTag( "Date", Concatenation(
-                String( Int( i[1] ) ), " ", # remove leading 0, if any
-                months[Int(i[2])], " ",
-                i[3] ) );
+            i := List(i, Int);
+            OutWithTag( "Date", AUTODOC_FormatDate(i[3], i[2], i[1]) );
         else
             Print("Warning: could not parse package date '", argument_rec.Date, "\n");
             OutWithTag( "Date", argument_rec.Date );

--- a/gap/ToolFunctions.gd
+++ b/gap/ToolFunctions.gd
@@ -21,3 +21,5 @@ DeclareGlobalFunction( "AutoDoc_CreatePrintOnceFunction" );
 DeclareGlobalFunction( "AUTODOC_Diff" );
 
 DeclareGlobalFunction( "AUTODOC_TestWorkSheet" );
+
+DeclareGlobalFunction( "AUTODOC_FormatDate" );

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -295,7 +295,9 @@ function(ws)
     for f in filenames do
         expected := Filename(expecteddir, f);
         actual := Filename(actualdir, f);
-        AUTODOC_Diff("-u", expected, actual);
+        if 0 <> AUTODOC_Diff("-u", expected, actual) then
+            Error("diff detected");
+        fi;
     od;
 end);
 

--- a/tst/AUTODOC_SetIfMissing.tst
+++ b/tst/AUTODOC_SetIfMissing.tst
@@ -1,8 +1,0 @@
-gap> r:=rec();
-rec(  )
-gap> AUTODOC_SetIfMissing(r, "foo", 1);
-gap> r;
-rec( foo := 1 )
-gap> AUTODOC_SetIfMissing(r, "foo", 2);
-gap> r;
-rec( foo := 1 )

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -1,0 +1,52 @@
+#
+# test miscellaneous stuff
+#
+gap> START_TEST( "misc.tst" );
+
+# AUTODOC_SetIfMissing
+gap> r:=rec();
+rec(  )
+gap> AUTODOC_SetIfMissing(r, "foo", 1);
+gap> r;
+rec( foo := 1 )
+gap> AUTODOC_SetIfMissing(r, "foo", 2);
+gap> r;
+rec( foo := 1 )
+
+#
+# AUTODOC_FormatDate
+#
+
+#
+gap> AUTODOC_FormatDate(2019);
+"2019"
+gap> AUTODOC_FormatDate(2019, 3);
+"March 2019"
+gap> AUTODOC_FormatDate(2019, 3, 1);
+"1 March 2019"
+gap> AUTODOC_FormatDate("2019", "3", "1");
+"1 March 2019"
+gap> AUTODOC_FormatDate(rec(year:=2019));
+"2019"
+gap> AUTODOC_FormatDate(rec(year:=2019, month:=3));
+"March 2019"
+gap> AUTODOC_FormatDate(rec(year:=2019, month:=3, day:=1));
+"1 March 2019"
+gap> AUTODOC_FormatDate(rec(year:="2019", month:="3", day:="1"));
+"1 March 2019"
+
+# error handling
+gap> AUTODOC_FormatDate();
+Error, Invalid arguments
+gap> AUTODOC_FormatDate(2019, 3, 40);
+Error, <day> must be an integer in the range [1..31], or a string representing\
+ such an integer
+gap> AUTODOC_FormatDate(2019, 13, 1);
+Error, <month> must be an integer in the range [1..12], or a string representi\
+ng such an integer
+gap> AUTODOC_FormatDate(fail, 3, 1);
+Error, <year> must be an integer >= 2000, or a string representing such an int\
+eger
+
+#
+gap> STOP_TEST( "misc.tst" );

--- a/tst/worksheets/general.expected/title.xml
+++ b/tst/worksheets/general.expected/title.xml
@@ -6,6 +6,6 @@
     General Test
   </Title>
   <Date>
-    2018 August 30
+    30 August 2018
   </Date>
   </TitlePage>

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -11,7 +11,7 @@
 Print( "Pretend this is a code file.\n" );
 Print( "(Even though we never use it that way.\n" );
 #! @Title General Test
-#! @Date 2018/08/30
+#! @Date 30/08/2018
 #! @Chapter SomeChapter
 #! This is dummy text
 #! @BeginExampleSession


### PR DESCRIPTION
This way, other code can format dates in a "human friendly" fashion, e.g. for use in XML entities for the package date.

Perhaps something like this should instead be added to GAP itself, or the utils package, but we can start here for now.