### PR TITLE
Recognize extract_examples as option to AutoDoc

### DIFF
--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -146,7 +146,7 @@ function( arg )
     # Check for user supplied options. If present, they take
     # precedence over any defaults as well as the opt record.
     #
-    for key in [ "dir", "scaffold", "autodoc", "gapdoc", "maketest" ] do
+    for key in [ "dir", "scaffold", "autodoc", "gapdoc", "maketest", "extract_examples" ] do
         val := ValueOption( key );
         if val <> fail then
             opt.(key) := val;


### PR DESCRIPTION
There are two ways to pass options to the `AutoDoc` function:

(1) Using the "options stack": `AutoDoc( package : options )`

(2) Using a second argument which is a record: `AutoDoc( package, options )`

All the options that `AutoDoc` expect can be passed in either of these
two forms, except the option `extract_examples`, which is only accepted
in form (2).  I changed this so that `extract_examples` is accepted in
both forms.

(It seems like form (1) is undocumented.  An alternative approach to
fix this inconsistency -- and avoid similar inconsistencies in the
future -- would be to remove form (1) completely.)