### PR TITLE
Add syntax for references

### DIFF
--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -739,6 +739,34 @@ can be important.</E>
 
 </Subsection>
 
+<Subsection Label="MarkdownExtensionRef">
+  <Heading>References</Heading>
+
+  One can create a reference to a documented declaration (function, operation, etc)
+  by writing a hash symbol (#) in front of the name.  Example:
+
+<Listing><![CDATA[
+#! See also #AutoDocWorksheet.
+]]></Listing>
+
+  This produces the following output:<Br/>
+  See also <Ref Func="AutoDocWorksheet" />.
+  <P/>
+
+  For references to operations, attributes and properties,
+  the argument filters must be included,
+  as a comma-separated list in square brackets.
+  For example, if an operation is declared as
+<Listing><![CDATA[
+DeclareOperation( "DoSomething", [ IsInt, IsRat ] );
+]]></Listing>
+  then we can refer to it by writing
+<Listing><![CDATA[
+#! See also #DoSomething[IsInt,IsRat].
+]]></Listing>
+
+</Subsection>
+
 </Section>
 
 </Chapter>

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -42,10 +42,29 @@ This is <Code>inline code</Code> in a list item.
 </List>
 <P/>
 All of this can <Emph>also</Emph> be <Emph>used</Emph> outside of a <Code>list</Code>.
+<P/>
+We can refer to <Ref Func="AnOperation" Label="for IsInt, IsList" />
+or to <Ref Func="AnOperation" Label="for IsRat" />.
 <ManSection>
   <InfoClass Name="InfoTESTCLASS" />
  <Description>
 An info class
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Oper Arg="x, y" Name="AnOperation" Label="for IsInt, IsList"/>
+ <Description>
+An operation.
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Oper Arg="r" Name="AnOperation" Label="for IsRat"/>
+ <Description>
+An operation.
  </Description>
 </ManSection>
 

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -33,8 +33,20 @@ Print( "(Even though we never use it that way.\n" );
 #! * This is `inline code` in a list item.
 #!
 #! All of this can **also** be __used__ outside of a `list`.
+#!
+#! We can refer to #AnOperation[IsInt,IsList]
+#! or to #AnOperation[IsRat].
 
 #! @Description
 #!   An info class
 DeclareInfoClass("InfoTESTCLASS");
 
+#! @Description
+#!  An operation.
+#! @Arguments x, y
+DeclareOperation( "AnOperation", [ IsInt, IsList ] );
+
+#! @Description
+#!  An operation.
+#! @Arguments r
+DeclareOperation( "AnOperation", [ IsRat ] );


### PR DESCRIPTION
I think it would be nice to have an XML-free syntax for writing references.

I suggest that the name of a function prefixed with a hash symbol should give a reference, so that the AutoDoc code

```
#SomeFunction
```

is translated to the GAPDoc code

```
<Ref Func="SomeFunction" />
```

For operations, attributes and properties, we need to include the argument filters as well.  I suggest the syntax

```
#SomeOperation[IsInt,IsGroup]
```

which is translated to

```
<Ref Func="SomeOperation" Label="for IsInt, IsGroup" />
```

This pull request is my attempt to implement this, including documentation and tests.

Some points for discussion:

1. Is the syntax acceptable?  For me, this seems like a reasonable way to write references (for instance, it is similar to the syntax for referring to issues on Github).  What do you think?
2. Is it safe to always use the `Func` attribute to `Ref`, instead of using `Oper`, `Attr` and so on?  It is easier to generate the GAPDoc code this way (we don't have to find out what kind of thing we refer to), and I'm not able to see that it makes any difference in the final result.