### PR TITLE
Replace scaffold.gapdoc_latex_options by gapdoc.LaTeXOptions

### DIFF
--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -346,7 +346,7 @@ Edit <File>PackageName/makedoc.g</File> as follows.
   add <Code>LoadPackage("PackageName");</Code>. 
   </Item> 
   <Item> 
-  In the <Code>AutoDoc</Code> record delete <Code>AutoDoc := true;</Code>. 
+  In the <Code>AutoDoc</Code> record delete <Code>autodoc := true;</Code>. 
   </Item>
   <Item> 
   <Index Key="Scaffold record in makedoc.g"></Index> 
@@ -364,12 +364,16 @@ Edit <File>PackageName/makedoc.g</File> as follows.
   you should rename this file <File>PackageName.bib</File>. 
   </Item>
   <Item> 
-  In the <Code>gapdoc_latex_options</Code> record enter any 
+  <Index Key="LaTeXOptions record in makedoc.g"></Index>
+  In the <Code>LaTeXOptions</Code> record,
+  which is in the <Code>gapdoc</Code> record, enter any
   &LaTeX; <Code>newcommands</Code> previously in <File>manual.xml</File>. 
   (If there are none you may safely delete this record.) 
-  To illustrate this option the &AutoDoc; file <File>makedoc.g</File> 
-  defines the command <Code>\bbZ</Code> which may be used to produce 
-  the &LaTeX; formula <M>f : \bbZ^2 \to \bbZ</M>. 
+  To illustrate this option, the &AutoDoc; file <File>makedoc.g</File>
+  defines the command <Code>\bbZ</Code>
+  by <Code>\newcommand{\bbZ}{\mathbb{Z}}</Code>,
+  which may be used to produce
+  the &LaTeX; formula <M>f : \bbZ^2 \to \bbZ</M>.
   </Item>
   <Item> 
   <Index Key="Entities record in makedoc.g"></Index> 

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -178,13 +178,6 @@
 #!             Replaces the standard header from &GAPDoc; completely with the header in this LaTeX file.
 #!             Please be careful here, and look at GAPDoc's latexheader.tex file for an example.
 #!         </Item>
-#!         <Mark><A>gapdoc_latex_options</A></Mark>
-#!         <Item>
-#!             Must be a record with entries which can be understood by SetGapDocLaTeXOptions. Each entry can be a string, which
-#!             will be given to &GAPDoc; directly, or a list containing of two entries: The first one must be the string "file",
-#!             the second one a filename. This file will be read and then its content is passed to &GAPDoc; as option with the name
-#!             of the entry.
-#!         </Item>
 #!
 #!         </List>
 #!     </Item>
@@ -296,6 +289,17 @@
 #!             <Br/>
 #!             <E>Default value: <C>[ ".", "gap", "lib", "examples", "examples/doc" ]</C>.</E>
 #!         </Item>
+#!
+#!         <Mark><A>LaTeXOptions</A></Mark>
+#!         <Item>
+#!             Must be a record with entries which can be understood by
+#!             <Ref Func='SetGapDocLaTeXOptions' BookName='gapdoc'/>. Each entry can be a
+#!             string, which will be given to &GAPDoc; directly, or a list containing of
+#!             two entries: The first one must be the string "file", the second one a
+#!             filename. This file will be read and then its content is passed to &GAPDoc;
+#!             as option with the name of the entry.
+#!         </Item>
+#!
 #!         <Mark><A>gap_root_relative_path</A></Mark>
 #!         <Item>
 #!             Either a boolean, or a string containing a relative path.

--- a/makedoc.g
+++ b/makedoc.g
@@ -7,16 +7,18 @@
 
 LoadPackage("AutoDoc");
 
-AutoDoc(rec( 
+AutoDoc( rec( 
     autodoc := true,
+    gapdoc := rec(
+        LaTeXOptions := rec( EarlyExtraPreamble := """
+            \usepackage{a4wide}
+            \newcommand{\bbZ}{\mathbb{Z}}
+        """ )
+    ),
     scaffold := rec(
         includes := [ "Tutorials.xml", 
                       "Comments.xml" ],
         bib := "bib.xml", 
-        gapdoc_latex_options := rec( EarlyExtraPreamble := """
-            \usepackage{a4wide} 
-            \newcommand{\bbZ} {\mathbb{Z}}
-        """ ),  
         entities := rec( 
             io := "<Package>io</Package>", 
             PackageName := "<Package>PackageName</Package>" 

--- a/tst/manual.expected/_Chapter_AutoDoc.xml
+++ b/tst/manual.expected/_Chapter_AutoDoc.xml
@@ -171,13 +171,6 @@ the option string ( contained in [ ] ) in LaTeX.
 Replaces the standard header from &GAPDoc; completely with the header in this LaTeX file.
 Please be careful here, and look at GAPDoc's latexheader.tex file for an example.
 </Item>
-<Mark><A>gapdoc_latex_options</A></Mark>
-<Item>
-Must be a record with entries which can be understood by SetGapDocLaTeXOptions. Each entry can be a string, which
-will be given to &GAPDoc; directly, or a list containing of two entries: The first one must be the string "file",
-the second one a filename. This file will be read and then its content is passed to &GAPDoc; as option with the name
-of the entry.
-</Item>
 </List>
 </Item>
 <Mark><A>autodoc</A></Mark>
@@ -257,6 +250,15 @@ which &AutoDoc; then scans for .gi, .gd and .g files; all of these files
 are then scanned for &GAPDoc; documentation comments.
 <Br/>
 <E>Default value: <C>[ ".", "gap", "lib", "examples", "examples/doc" ]</C>.</E>
+</Item>
+<Mark><A>LaTeXOptions</A></Mark>
+<Item>
+Must be a record with entries which can be understood by
+<Ref Func='SetGapDocLaTeXOptions' BookName='gapdoc'/>. Each entry can be a
+string, which will be given to &GAPDoc; directly, or a list containing of
+two entries: The first one must be the string "file", the second one a
+filename. This file will be read and then its content is passed to &GAPDoc;
+as option with the name of the entry.
 </Item>
 <Mark><A>gap_root_relative_path</A></Mark>
 <Item>


### PR DESCRIPTION
This is a first attempt to address issue #149. 
After these changes the following makedoc.g files appear to run correctly: (1) after changing to GAPDocLatexOptions - AutoDoc; XMod,  (2) still using gapdoc_latex_options: groupoids; intpic; factint; sgpviz, xmodalg.  The makedoc.g in numericalsgps throws a lot of 'inputenc Errors', but that may not be due to this PR? 
Question: should the entities also be moved from scaffold to gapdoc? 

Resolves #149