### PR TITLE
Implicitly end subsection when a manpage starts; add deprecation warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 This file describes changes in the AutoDoc package.
 
+TODO
+  - Add deprecation warnings for @InsertSystem, @System, @BeginSystem, @EndSystem
+    (use @Chunk etc. instead), and also @EndSection, @EndSubsection
+  - Minor fixes in the manual
+
 2019.04.10
   - Add opt.extract_examples to AutoDoc function
   - Add @NotLatex command to complement @LatexOnly

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -200,14 +200,7 @@ can be used to set a heading for the section that is different from <A>name</A>.
 <Subsection Label="@EndSection">
 <Index Key="@EndSection"><C>@EndSection</C></Index>
 <Heading><C>@EndSection</C></Heading>
-Closes the current section. Please be careful here. Closing a section before
-opening it might cause unexpected errors.
-
-<Listing><![CDATA[
-#! @EndSection
-#### The following text again belongs to the chapter
-#! Now we could start a second section if we want to.
-]]></Listing>
+<Emph>This command is deprecated.</Emph> You can simply remove any use of it.
 </Subsection>
 
 <Subsection Label="@Subsection">
@@ -237,13 +230,7 @@ can be used to set a heading for the subsection that is different from <A>name</
 <Subsection Label="@EndSubsection">
 <Index Key="@EndSubsection"><C>@EndSubsection</C></Index>
 <Heading><C>@EndSubsection</C></Heading>
-Closes the current subsection. Please be careful here. Closing a subsection before
-opening it might cause unexpected errors.
-<Listing><![CDATA[
-#! @EndSubsection
-#### The following text again belongs to the section
-#! Now we are in the section again
-]]></Listing>
+<Emph>This command is deprecated.</Emph> You can simply remove any use of it.
 </Subsection>
 
 <Subsection Label="@BeginAutoDoc">
@@ -467,7 +454,8 @@ And then later, insert the example in a different file, like this:
 <Index Key="@EndSystem"><C>@EndSystem</C></Index>
 <Index Key="@InsertSystem"><C>@InsertSystem <A>name</A></C></Index>
 <Heading><C>@BeginSystem <A>name</A></C>, <C>@EndSystem</C>, and <C>@InsertSystem <A>name</A></C></Heading>
-Same as <C>@BeginChunk</C> etc. These command are deprecated. Please use the chunk commands instead.
+<Emph>These command are deprecated.</Emph> Please use the chunk commands from subsection
+<Ref Subsect="@BeginCode"/> instead.
 </Subsection>
 
 <Subsection Label="@BeginCode">

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -182,6 +182,7 @@ for setting the same chapter as active chapter again.
 <Index Key="@SectionTitle"><C>@SectionTitle</C></Index>
 <Heading><C>@Section <A>name</A></C></Heading>
 Sets an active section like <C>@Chapter</C> sets an active chapter.
+The section automatically ends with the next <C>@Section</C> or <C>@Chapter</C> command.
 
 <Listing><![CDATA[
 #! @Section My first manual section
@@ -214,7 +215,11 @@ opening it might cause unexpected errors.
 <Index Key="@SubsectionLabel"><C>@SubsectionLabel</C></Index>
 <Index Key="@SubsectionTitle"><C>@SubsectionTitle</C></Index>
 <Heading><C>@Subsection <A>name</A></C></Heading>
-Sets an active subsection like <C>@Chapter</C> sets an active chapter.
+Sets an active subsection like <C>@Section</C> sets an active section.
+The subsection automatically ends with the next <C>@Subsection</C>,
+<C>@Section</C> or <C>@Chapter</C> command. It also ends with the
+next documented function. Indeed, internally each function <Q>manpage</Q>
+is treated like a subsection.
 
 <Listing><![CDATA[
 #! @Subsection My first manual subsection

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -104,7 +104,7 @@ leads to this:
 
 <Subsection Label="@ChapterInfo">
 <Index Key="@ChapterInfo"><C>@ChapterInfo</C></Index>
-<Heading>@ChapterInfo <A>chapter, section</A></Heading>
+<Heading><C>@ChapterInfo <A>chapter</A>, <A>section</A></C></Heading>
 Adds the entry to the given chapter and section. Here,
 <A>chapter</A> and <A>section</A> are the respective
 titles.
@@ -198,7 +198,7 @@ can be used to set a heading for the section that is different from <A>name</A>.
 
 <Subsection Label="@EndSection">
 <Index Key="@EndSection"><C>@EndSection</C></Index>
-<Heading>@EndSection</Heading>
+<Heading><C>@EndSection</C></Heading>
 Closes the current section. Please be careful here. Closing a section before
 opening it might cause unexpected errors.
 
@@ -231,7 +231,7 @@ can be used to set a heading for the subsection that is different from <A>name</
 
 <Subsection Label="@EndSubsection">
 <Index Key="@EndSubsection"><C>@EndSubsection</C></Index>
-<Heading>@EndSubsection</Heading>
+<Heading><C>@EndSubsection</C></Heading>
 Closes the current subsection. Please be careful here. Closing a subsection before
 opening it might cause unexpected errors.
 <Listing><![CDATA[
@@ -243,7 +243,7 @@ opening it might cause unexpected errors.
 
 <Subsection Label="@BeginAutoDoc">
 <Index Key="@BeginAutoDoc"><C>@BeginAutoDoc</C></Index>
-<Heading>@BeginAutoDoc</Heading>
+<Heading><C>@BeginAutoDoc</C></Heading>
 Causes all subsequent declarations to be documented in the manual,
 regardless of whether they have an &AutoDoc; comment in front of
 them or not.
@@ -251,7 +251,7 @@ them or not.
 
 <Subsection Label="@EndAutoDoc">
 <Index Key="@EndAutoDoc"><C>@EndAutoDoc</C></Index>
-<Heading>@EndAutoDoc</Heading>
+<Heading><C>@EndAutoDoc</C></Heading>
 Ends the effect of <C>@BeginAutoDoc</C>. So from here on, again only declarations
 with an explicit &AutoDoc; comment in front are added to the manual.
 
@@ -269,7 +269,7 @@ Both, <C>Operation1</C> and <C>IsProperty</C> would appear in the manual.
 
 <Subsection Label="@BeginGroup">
 <Index Key="@BeginGroup"><C>@BeginGroup</C></Index>
-<Heading>@BeginGroup <A>[grpname]</A></Heading>
+<Heading><C>@BeginGroup <A>[grpname]</A></C></Heading>
 Starts a group. All following documented declarations without an
 explicit <C>@Group</C> command are grouped together in the same group
 with the given name. If no name is given, then a new nameless group is
@@ -283,7 +283,7 @@ See section <Ref Sect="Groups"/> for more information about groups.
 
 <Subsection Label="@EndGroup">
 <Index Key="@EndGroup"><C>@EndGroup</C></Index>
-<Heading>@EndGroup</Heading>
+<Heading><C>@EndGroup</C></Heading>
 Ends the current group.
 
 <Listing><![CDATA[
@@ -503,7 +503,7 @@ in the PDF version of the manual or worksheet. It can hold arbitrary LaTeX-comma
 <Index Key="@NotLatex"><C>@NotLatex <A>text</A></C></Index>
 <Index Key="@BeginNotLatex"><C>@BeginNotLatex</C></Index>
 <Index Key="@EndNotLatex"><C>@EndNotLatex</C></Index>
-<Heading>@NotLatex <A>text</A>, <C>@BeginNotLatex</C> , and <C>@EndNotLatex</C></Heading>
+<Heading><C>@NotLatex <A>text</A></C>, <C>@BeginNotLatex</C>, and <C>@EndNotLatex</C></Heading>
 Code inserted between <C>@BeginNotLatex</C> and <C>@EndNotLatex</C> or after <C>@NotLatex</C> is inserted
 in the HTML and text versions of the manual or worksheet, but not in the PDF version.
 <Listing><![CDATA[

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -168,10 +168,18 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         if IsBound( current_item ) and IsTreeForDocumentationNodeForManItemRep( current_item ) then
             return current_item;
         fi;
-        man_item := DocumentationManItem( tree );
+
+        # implicitly end any subsection
+        if IsBound( chapter_info[ 3 ] ) then
+            Unbind( chapter_info[ 3 ] );
+            current_item := SectionInTree( tree, chapter_info[ 1 ], chapter_info[ 2 ] );
+        fi;
+
         if IsBound( current_item ) then
             Add( context_stack, current_item );
         fi;
+
+        man_item := DocumentationManItem( tree );
         if IsBound( scope_group ) then
             SetGroupName( man_item, scope_group );
         fi;


### PR DESCRIPTION
Specifically, add deprecation warnings for @InsertSystem, @System, @BeginSystem, @EndSystem (use @Chunk etc. instead), and also @EndSection, @EndSubsection.

These warnings are shown for info level InfoWarning >= 1, and in red color to make sure they are seen by the user.

Also, the manual was changed to document these tags as deprecated, and what to use instead.

This mostly resolves the issues #205 and #206; however, we might keep those open to remind us that one day in the future (let's say, in one year?) we could make a release were those deprecated tags are completely removed; or at least removed from the manual.