### PR TITLE
Add @GroupTitle command

### DIFF
--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -294,6 +294,14 @@ DeclareOperation( "GroupedOperation",
 ]]></Listing>
 </Subsection>
 
+<Subsection Label="@GroupTitle">
+<Index Key="@GroupTitle"><C>@GroupTitle</C></Index>
+<Heading>@GroupTitle <A>title</A></Heading>
+Sets the subsection heading for the current group to <A>title</A>. In the
+absence of any <C>@GroupTitle</C> command, the heading will be the name of the
+first entry in the group. See <Ref Sect="Groups" /> for more information.
+</Subsection>
+
 <Subsection Label="@Level">
 <Index Key="@Level"><C>@Level</C></Index>
 <Heading><C>@Level <A>lvl</A></C></Heading>
@@ -573,13 +581,14 @@ regarded as &AutoDoc; parts. All commands can be used like before.
 <Section Label="Groups">
 <Heading>Grouping</Heading>
 
-In &GAPDoc;, it is possible to make groups of ManItems, i.e., when documenting
+In &GAPDoc;, it is possible to make groups of manual items, i.e., when documenting
 a function, operation, etc., it is possible to group them into suitable chunks.
 This can be particularly useful if there are several definitions of an operation
 with several different argument types, all doing more or less the same to the arguments.
 Then their manual items can be grouped, sharing the same description and return type information.
-Note that it is currently not possible to give a header to the Group in the manual,
-but the generated ManItem heading of the first entry will be used.
+You can give a heading to the group in the manual with the <C>@GroupTitle</C>
+command; if that is not supplied, then the heading of the first  manual item
+in the group will be used as the heading.
 <P/>
 
 Note that group names are globally unique throughout the whole manual.
@@ -592,9 +601,12 @@ same group name, in different places, and these all will refer to the same group
 Moreover, this means that you can add items to a group via the <C>@Group</C> command
 in the &AutoDoc; comment of an arbitrary declaration, at any time.
 
+<P/>
+
 The following code
 <Listing><![CDATA[
 #! @BeginGroup Group1
+#! @GroupTitle A family of operations
 
 #! @Description
 #!  First sentence.
@@ -617,14 +629,14 @@ KeyDependentOperation( "ThirdOperation", IsGroup, IsInt, "prime );
 produces the following:
 
 <ManSection Label="Group1">
+<Heading>A family of operations</Heading>
   <Oper Arg="arg" Name="FirstOperation" Label="for IsInt"/>
   <Oper Arg="arg1,arg2" Name="SecondOperation" Label="for IsInt, IsGroup"/>
   <Oper Arg="arg1,arg2" Name="ThirdOperation" Label="for IsGroup, IsInt"/>
- <Returns></Returns>
  <Description>
- First sentence.
- Second sentence.
- Third sentence.
+First sentence.
+Second sentence.
+Third sentence.
  </Description>
 </ManSection>
 

--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -612,16 +612,21 @@ InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForManItemRep, Is
     if node!.level > ValueOption( "level_value" ) then
         return;
     fi;
-    AutoDoc_WriteDocEntry( filestream, [ node ] );
+    AutoDoc_WriteDocEntry( filestream, [ node ], fail );
 end );
 
 ##
 InstallMethod( WriteDocumentation, [ IsTreeForDocumentationNodeForGroupRep, IsStream ],
   function( node, filestream )
+    local heading;
     if node!.level > ValueOption( "level_value" ) then
         return;
     fi;
-    AutoDoc_WriteDocEntry( filestream, node!.content );
+    heading := fail;
+    if IsBound( node!.title_string ) then
+        heading := node!.title_string;
+    fi;
+    AutoDoc_WriteDocEntry( filestream, node!.content, heading );
 end );
 
 ##

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -655,6 +655,28 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             group_name := ReplacedString( current_command[ 2 ], " ", "_" );
             SetGroupName( current_item, group_name );
         end,
+        @GroupTitle := function()
+            local group_name, chap_info, group_obj;
+            current_item := new_man_item();
+            if not HasGroupName( current_item ) then
+                ErrorWithPos( "found @GroupTitle with no Group set" );
+            fi;
+            group_name := GroupName( current_item );
+            chap_info := fail;
+            if HasChapterInfo( current_item ) then
+                chap_info := ChapterInfo( current_item );
+            elif IsBound( current_item!.chapter_info ) then
+                chap_info := current_item!.chapter_info;
+            fi;
+            if chap_info = fail or Length( chap_info ) = 0 then
+                chap_info := chapter_info;
+            fi;
+            if Length( chap_info ) <> 2 then
+                ErrorWithPos( "can only set @GroupTitle within a Chapter and Section.");
+            fi;
+            group_obj := DocumentationGroup( tree, group_name, chap_info );
+            group_obj!.title_string := current_command[ 2 ];
+        end,
         @ChapterInfo := function()
             local current_chapter_info;
             current_item := new_man_item();

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -49,7 +49,7 @@ end );
 
 ##
 InstallGlobalFunction( AutoDoc_WriteDocEntry,
-  function( filestream, list_of_records )
+  function( filestream, list_of_records, heading )
     local return_value, description, current_description, labels, i;
 
     # look for a good return value (it should be the same everywhere)
@@ -102,7 +102,12 @@ InstallGlobalFunction( AutoDoc_WriteDocEntry,
     od;
     AppendTo( filestream, ">\n" );
 
-    # Function heades
+    # Next possibly the heading for the entry
+    if IsString( heading ) then
+        AppendTo( filestream, "<Heading>", heading, "</Heading>\n" );
+    fi;
+
+    # Function headers
     for i in list_of_records do
          AppendTo( filestream, "  <", i!.item_type, " " );
         if i!.arguments <> fail and i!.item_type <> "Var" then

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -113,5 +113,24 @@ This text will only appear in the HTML version and the text version, too.
 </Section>
 
 
+<Section Label="Chapter_SomeChapter_Section_Testing_the_group_commands">
+<Heading>Testing the group commands</Heading>
+
+<ManSection Label="Group1">
+<Heading>A family of operations</Heading>
+  <Oper Arg="arg" Name="FirstOperation" Label="for IsInt"/>
+  <Oper Arg="arg1,arg2" Name="SecondOperation" Label="for IsInt, IsGroup"/>
+  <Oper Arg="arg1,arg2" Name="ThirdOperation" Label="for IsGroup, IsInt"/>
+ <Description>
+First sentence.
+Second sentence.
+Third sentence.
+ </Description>
+</ManSection>
+
+
+</Section>
+
+
 </Chapter>
 

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -22,6 +22,7 @@ Print( "(Even though we never use it that way.\n" );
 #! @EndExampleSession
 #! And we wrap up with some dummy text
 
+#############################################################################
 #! @Section Some categories
 #!  Intro text
 DeclareCategory("MyThings", IsObject);
@@ -32,6 +33,7 @@ Now here is some text with a bunch of &!$%*!/ weird things in it. But that
 should be OK, nothing should end up in a weird place.
 #! Let's wrap up with something, though.
 
+#############################################################################
 #! @Section SomeSection
 
 #! Some test just inside a section. We can use test some markdown features here:
@@ -57,3 +59,26 @@ DeclareInfoClass("InfoTESTCLASS");
 #! @BeginNotLatex
 #! This text will only appear in the HTML version and the text version, too.
 #! @EndNotLatex
+
+#############################################################################
+#! @Section Testing the group commands
+
+#! @BeginGroup Group1
+#! @GroupTitle A family of operations
+
+#! @Description
+#!  First sentence.
+DeclareOperation( "FirstOperation", [ IsInt ] );
+
+#! @Description
+#!  Second sentence.
+DeclareOperation( "SecondOperation", [ IsInt, IsGroup ] );
+
+#! @EndGroup
+
+## .. Stuff ..
+
+#! @Description
+#!  Third sentence.
+#! @Group Group1
+KeyDependentOperation( "ThirdOperation", IsGroup, IsInt, "prime );


### PR DESCRIPTION
Previously, there was no way to modify the subsection heading of a @Group, but
the documentation even stated "Note that it is currently not possible to give
a header to the Group in the manual..." Hence, the addition of a @GroupTitle
command to allow exactly that.

Co-Authored-By: Max Horn <max@quendi.de>

Resolves #90 
Closes #172 (this is a modified version of that PR, which was authored by @gwhitney, with `@GroupInitialArguments` removed, a test added, some wording updated