### PR TITLE
Made Chunks compatible with GAPDoc chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,9 @@
 /doc/*.tex
 /doc/*.toc
 /doc/*.txt
-/doc/*Bib.xml
 /doc/*.xml.bib
 /doc/AutoDoc.xml
-/doc/_AutoDocMainFile.xml
-/doc/_Chapter*xml
+/doc/_*.xml
 /doc/maketest.g
 /doc/manual.lab
 /doc/manual.six

--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -166,7 +166,8 @@ InstallMethod( DocumentationTree, [ ],
                   nodes_by_label := rec( ),
                   node_name_iterator := 0,
                   current_level := 0,
-                  TitlePage := rec( )
+                  TitlePage := rec( ),
+                  chunks := rec( ),
             );
     ObjectifyWithAttributes( tree, TheTypeOfDocumentationTrees );
     return tree;
@@ -246,15 +247,14 @@ InstallMethod( DocumentationDummy, [ IsTreeForDocumentation, IsString ],
   function( tree, name )
     local node;
 
-    name := Concatenation( "System_", name );
-    if IsBound( tree!.nodes_by_label.( name ) ) then
-        return tree!.nodes_by_label.( name );
+    if IsBound( tree!.chunks.( name ) ) then
+        return tree!.chunks.( name );
     fi;
     node := rec( content := [ ],
                  level := tree!.current_level );
     ObjectifyWithAttributes( node, TheTypeOfDocumentationTreeDummyNodes,
                               Label, name );
-    tree!.nodes_by_label.( name ) := node;
+    tree!.chunks.( name ) := node;
     return node;
 end );
 
@@ -449,6 +449,29 @@ end );
 ##
 #############################################
 
+BindGlobal( "WriteChunks",
+  function( tree, path_to_xmlfiles )
+    local chunks_stream, filename, chunk_names, current_chunk_name,
+          current_chunk;
+
+    filename := "_Chunks.xml";
+
+    chunks_stream := AUTODOC_OutputTextFile( path_to_xmlfiles, filename );
+    chunk_names := RecNames( tree!.chunks );
+
+    for current_chunk_name in chunk_names do
+        current_chunk := tree!.chunks.( current_chunk_name );
+        AppendTo( chunks_stream, "<#GAPDoc Label=\"", current_chunk_name, "\">\n" );
+        if IsBound( current_chunk!.content ) then
+            WriteDocumentation( current_chunk!.content, chunks_stream );
+        fi;
+        AppendTo( chunks_stream, "\n<#/GAPDoc>\n" );
+    od;
+
+    CloseStream( chunks_stream );
+
+end );
+
 ##
 InstallMethod( WriteDocumentation, [ IsTreeForDocumentation, IsDirectory ],
   function( tree, path_to_xmlfiles )
@@ -463,6 +486,9 @@ InstallMethod( WriteDocumentation, [ IsTreeForDocumentation, IsDirectory ],
         ## FIXME: If there is anything else than a chapter, this will break!
         WriteDocumentation( i, stream, path_to_xmlfiles );
     od;
+
+    WriteChunks( tree, path_to_xmlfiles );
+
     # Workaround for issue #65
     if IsEmpty( tree!.content ) then
         AppendTo( stream, "&nbsp;\n" );
@@ -632,9 +658,10 @@ end );
 ##
 InstallMethod( WriteDocumentation, [ IsTreeForDocumentationDummyNodeRep, IsStream ],
   function( node, filestream )
-    if IsBound( node!.content ) then
-        WriteDocumentation( node!.content, filestream );
+    if node!.level > ValueOption( "level_value" ) then
+        return;
     fi;
+    WriteDocumentation( Concatenation( "<#Include Label=\"", Label( node ), "\">" ), filestream );
 end );
 
 ##

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -348,6 +348,7 @@ function( arg )
             tmp := Number( Filename( doc_dir_rel, "" ), x -> x = '/' );
             tmp := Concatenation( ListWithIdenticalEntries(tmp, "../") );
             gapdoc.files := List( gapdoc.files, f -> Concatenation( tmp, f ) );
+            Add( gapdoc.files, "_Chunks.xml" );
         else
             # Here presumably the doc_dir was given by an absolute path that
             # does not lie below the package dir. In that case, we can't make
@@ -355,6 +356,7 @@ function( arg )
             # choice but to make them absolute, which MakeGAPDocDoc can handle,
             # even if perhaps less gracefully/portably.
             gapdoc.files := List( gapdoc.files, f -> Filename( pkgdir, f ) );
+            Add( gapdoc.files, Filename( doc_dir, "_Chunks.xml" ) );
         fi;
     fi;
 

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -132,5 +132,15 @@ Third sentence.
 </Section>
 
 
+<Section Label="Chapter_SomeChapter_Section_Testing_chunks">
+<Heading>Testing chunks</Heading>
+
+This test comes after the chunk is declared, but before it is inserted.
+<#Include Label="MyChunk">
+
+The text "Hello, world." is inserted right before this.
+</Section>
+
+
 </Chapter>
 

--- a/tst/worksheets/general.expected/_Chunks.xml
+++ b/tst/worksheets/general.expected/_Chunks.xml
@@ -1,0 +1,4 @@
+<#GAPDoc Label="MyChunk">
+Hello, world.
+
+<#/GAPDoc>

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -77,3 +77,16 @@ DeclareOperation( "SecondOperation", [ IsInt, IsGroup ] );
 #!  Third sentence.
 #! @Group Group1
 KeyDependentOperation( "ThirdOperation", IsGroup, IsInt, "prime );
+
+#############################################################################
+#! @Section Testing chunks
+
+#! @BeginChunk MyChunk
+#! Hello, world.
+#! @EndChunk
+
+#! This test comes after the chunk is declared, but before it is inserted.
+
+#! @InsertChunk MyChunk
+
+#! The text "Hello, world." is inserted right before this.


### PR DESCRIPTION
Implements #217 by making `@Chunk` using `<#GAPDoc Label=...>`.

Resolves #217 