### PR TITLE
Add support for DeclareFamilyProperty

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "AutoDoc",
 Subtitle := "Generate documentation from GAP source code",
-Version := "2019.09.04",
+Version := "2020.01.13",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -86,6 +86,11 @@ InstallGlobalFunction( AutoDoc_Type_Of_Item,
         entries := [ "Prop", "properties" ];
         ret_val := "<C>true</C> or <C>false</C>";
         has_filters := 1;
+    elif PositionSublist( type, "DeclareFamilyProperty" ) <> fail then
+        # a CAP-specific version of DeclareProperty
+        entries := [ "Prop", "properties" ];
+        ret_val := "<C>true</C> or <C>false</C>";
+        has_filters := 1;
     elif PositionSublist( type, "DeclareOperation" ) <> fail then
         entries := [ "Oper", "methods" ];
         has_filters := "List";


### PR DESCRIPTION
This is a CAP-specific version of DeclareProperty with the signature
`DeclareFamilyProperty( name, filter[, family, type of cell ] )`

The CAP-PR making use of this is https://github.com/homalg-project/CAP_project/pull/459

@sebastianpos are you aware of further CAP-specific versions of declarations?