### PR TITLE
Remove duplicate entries in autodoc.files

### DIFF
--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -254,6 +254,7 @@ function( arg )
                 autodoc.scan_dirs := [ ".", "gap", "lib", "examples", "examples/doc" ];
             fi;
             Append( autodoc.files, AUTODOC_FindMatchingFiles(pkgdir, autodoc.scan_dirs, [ "g", "gi", "gd", "autodoc" ]) );
+            autodoc.files := DuplicateFreeList( autodoc.files );
         fi;
 
         # Make sure all of the files exist, making the file names absolute if


### PR DESCRIPTION
Application: I have multiple .autodoc files which should be detected via
"scan_dirs". However, there is a main .autodoc file which should be
included first as it defines the order of chapters and sections. Thus, I
pass this file to "files" explicitly. This commit makes sure that it is not
included twice if I do that.

Note: Since the order is relevant I have used DuplicateFreeList instead of
Set to keep the order of the first occurrence (which I hope
DuplicateFreeList actually does).