### PR TITLE
Correctly handle empty lines inside @BeginCode/@EndCode

### DIFF
--- a/gap/Markdown.gi
+++ b/gap/Markdown.gi
@@ -25,8 +25,20 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
 
     ## Check for paragraphs by turning an empty string into <P/>
     
+    skipped := false;
     already_inserted_paragraph := false;
     for i in [ 1 ..  Length( string_list ) ] do
+        if PositionSublist( string_list[ i ], "<![CDATA[" ) <> fail then
+            skipped := true;
+        fi;
+        if PositionSublist( string_list[ i ], "]]>" ) <> fail then
+            skipped := false;
+            continue;
+        fi;
+        if skipped = true then
+            continue;
+        fi;
+
         if NormalizedWhitespace( string_list[ i ] ) = "" then
             if already_inserted_paragraph = false then
                 string_list[ i ] := "<P/>";
@@ -35,7 +47,6 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
         else
             already_inserted_paragraph := false;
         fi;
-        i := i + 1;
     od;
 
     ## We need to find lists. Lists are indicated by a beginning

--- a/tst/worksheets/general.expected/_Chunks.xml
+++ b/tst/worksheets/general.expected/_Chunks.xml
@@ -7,6 +7,7 @@
 <Listing Type="Code"><![CDATA[
  Hello, world.
 x := 1 + 1;
+
 if x = 2 then
   Print("1 + 1 = 2 holds, all is good\n");
 else

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -179,6 +179,7 @@ DeclareOperation( "ThirdOperation", [ IsGroup, IsInt ] );
 #! @BeginCode MyCode
 #! Hello, world.
 x := 1 + 1;
+
 if x = 2 then
   Print("1 + 1 = 2 holds, all is good\n");
 else


### PR DESCRIPTION
Don't translate empty to `<P/>` if inside a CDATA section.

Fixes #251 ... except not quite: for some reason the empty line still gets removed. I'm too tired to figure this out now; if anybody (including future me) wants to pick it up from here, be my guest

CC @ssiccha 