### PR TITLE
let `AutoDoc` set an exit code in the case of failure

### DIFF
--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -265,6 +265,11 @@
 #!         In all other cases (in particular if <A>opt.gapdoc</A> is
 #!         <K>false</K>), this feature is disabled.
 #!         <P/>
+#!         If &GAPDoc; is invoked by <Ref Func="AutoDoc"/> then the returned
+#!         record has a component <C>GAPDoc_Info</C>, whose value is the
+#!         string obtained from collecting the info messages printed by
+#!         the &GAPDoc; functions.
+#!         <P/>
 #!
 #!         If <A>opt.gapdoc</A> is a record, it may contain the following entries.
 #!
@@ -395,12 +400,12 @@
 #! </Item>
 #! </List>
 #!
-#! @Returns nothing
+#! @Returns a record
 #! @Arguments [packageOrDirectory], [optrec]
 DeclareGlobalFunction( "AutoDoc" );
 
 
 #! @Section Examples
 #!
-#! Some basic examples for using <C>AutoDoc</C> were already shown in
+#! Some basic examples for using <Ref Func="AutoDoc"/> were already shown in
 #! Chapter <Ref Label='Tutorials'/>.

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -265,11 +265,6 @@
 #!         In all other cases (in particular if <A>opt.gapdoc</A> is
 #!         <K>false</K>), this feature is disabled.
 #!         <P/>
-#!         If &GAPDoc; is invoked by <Ref Func="AutoDoc"/> then the returned
-#!         record has a component <C>GAPDoc_Info</C>, whose value is the
-#!         string obtained from collecting the info messages printed by
-#!         the &GAPDoc; functions.
-#!         <P/>
 #!
 #!         If <A>opt.gapdoc</A> is a record, it may contain the following entries.
 #!
@@ -400,7 +395,7 @@
 #! </Item>
 #! </List>
 #!
-#! @Returns a record
+#! @Returns nothing
 #! @Arguments [packageOrDirectory], [optrec]
 DeclareGlobalFunction( "AutoDoc" );
 

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -677,8 +677,12 @@ function( arg )
     fi;
 
     if IsBound( outputstring ) then
-      return rec( GAPDoc_Info := outputstring );
-    else
-      return rec();
+      # If wanted then set an exit code for GAP.
+      if Number( SplitString( outputstring, "\n" ),
+                 x -> StartsWith( x, "#W " ) and not
+                      StartsWith( x, "#W There are overfull boxes" ) ) > 0 then
+        GapExitCode( false );
+      fi;
     fi;
+    return true;
 end );

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -73,7 +73,8 @@ function( arg )
           pkgdirstr, docdirstr,
           title_page, tree, is_worksheet,
           position_document_class,
-          args;
+          args,
+          outputstring, outputstream;
 
     if Length( arg ) >= 3 then
         Error( "too many arguments" );
@@ -589,8 +590,18 @@ function( arg )
             Add( args, "nopdf" );
         fi;
 
-        # Finally, invoke GAPDoc
+        # Finally, invoke GAPDoc (and collect info messages)
+        outputstring := "";
+        outputstream := OutputTextString( outputstring, true );
+        SetPrintFormattingStatus( outputstream, false );
+        SetInfoOutput( InfoGAPDoc, outputstream );
+        SetInfoOutput( InfoWarning, outputstream );
         CallFuncList( MakeGAPDocDoc, args );
+        CloseStream( outputstream );
+        UnbindInfoOutput( InfoGAPDoc );
+        UnbindInfoOutput( InfoWarning );
+        Print( outputstring );
+        outputstring := ReplacedString( outputstring, "\c", "" );
 
         # NOTE: We cannot just write CopyHTMLStyleFiles(doc_dir) here, as
         # CopyHTMLStyleFiles its argument directly to Directory(), leading
@@ -665,5 +676,9 @@ function( arg )
         AUTODOC_ExtractMyManualExamples( pkgname, pkgdir, doc_dir, gapdoc.main, gapdoc.files, extract_examples );
     fi;
 
-    return true;
+    if IsBound( outputstring ) then
+      return rec( GAPDoc_Info := outputstring );
+    else
+      return rec();
+    fi;
 end );

--- a/makedoc.g
+++ b/makedoc.g
@@ -7,7 +7,7 @@
 
 LoadPackage("AutoDoc");
 
-res:= AutoDoc( rec(
+AutoDoc( rec(
     autodoc := true,
     gapdoc := rec(
         LaTeXOptions := rec( EarlyExtraPreamble := """
@@ -21,13 +21,3 @@ res:= AutoDoc( rec(
         bib := "bib.xml", 
     )
 ));
-
-errors:= Filtered(SplitString( res.GAPDoc_Info, "\n"),
-            x -> StartsWith(x, "#W ") and x <> "#W There are overfull boxes:");
-if Length( errors ) = 0 then
-  QuitGap( true );
-else
-  Print( errors, "\n" );
-  QuitGap( false );
-fi;
-QUIT;

--- a/makedoc.g
+++ b/makedoc.g
@@ -7,7 +7,7 @@
 
 LoadPackage("AutoDoc");
 
-AutoDoc( rec( 
+res:= AutoDoc( rec(
     autodoc := true,
     gapdoc := rec(
         LaTeXOptions := rec( EarlyExtraPreamble := """
@@ -21,3 +21,13 @@ AutoDoc( rec(
         bib := "bib.xml", 
     )
 ));
+
+errors:= Filtered(SplitString( res.GAPDoc_Info, "\n"),
+            x -> StartsWith(x, "#W ") and x <> "#W There are overfull boxes:");
+if Length( errors ) = 0 then
+  QuitGap( true );
+else
+  Print( errors, "\n" );
+  QuitGap( false );
+fi;
+QUIT;

--- a/tst/manual.expected/_Chapter_AutoDoc.xml
+++ b/tst/manual.expected/_Chapter_AutoDoc.xml
@@ -364,7 +364,7 @@
 <Heading>Examples</Heading>
 
 <P/>
- Some basic examples for using <C>AutoDoc</C> were already shown in
+ Some basic examples for using <Ref Func="AutoDoc"/> were already shown in
  Chapter <Ref Label='Tutorials'/>.
 </Section>
 


### PR DESCRIPTION
The idea is the same as in gap-system/gap/pull/5835, but here we deal with package documentation:
When building a manual, collect the info messages printed by `MakeGAPDocDoc`, use a heuristic to decide whether the result is acceptable, and let `makedoc.g` report failure if not; this can be used in automated tests.

For that, the function `AutoDoc` now ~~returns a record; up to now, it had no return value.~~ sets a nonzero exit code if applicable.

This change will automatically become available in all packages that use `makedoc.g` containing `AutoDoc` calls. This should not cause problems because the exit code of processing `makedoc.g` did not have a meaning before the change.