### PR TITLE
Add InfoAutoDoc for messages instead of Printing

### DIFF
--- a/gap/AutoDocMainFunction.gi
+++ b/gap/AutoDocMainFunction.gi
@@ -285,7 +285,7 @@ InstallGlobalFunction( CreateTitlePage,
                 i := List(i, Int);
                 OutWithTag( "Date", AUTODOC_FormatDate(i[1], i[2], i[3]) );
             else
-                Print("Warning: could not parse package date '", argument_rec.Date, "'\n");
+                Info(InfoGAPDoc, 1, "Warning: could not parse package date '", argument_rec.Date, "'");
                 OutWithTag( "Date", argument_rec.Date );
             fi;
         fi;
@@ -426,7 +426,7 @@ BindGlobal("AUTODOC_ExtractMyManualExamples",
 function( pkgname, pkgdir, docdir, main, files, opt )
     local tst, i, s, basename, name, output, ch, a, location, pos, comment, pkgdirString,
       nonempty_units_found, number_of_digits, lpkgname, tstdir;
-    Print("Extracting manual examples for ", pkgname, " package ...\n" );
+    Info(InfoGAPDoc, 1, "Extracting manual examples for ", pkgname, " package ...");
 
     lpkgname := LowercaseString(pkgname);
     lpkgname := ReplacedString(lpkgname, " ", "_");
@@ -435,7 +435,7 @@ function( pkgname, pkgdir, docdir, main, files, opt )
         main := Concatenation( main, ".xml" );
     fi;
     tst:=ExtractExamples( docdir, main, files, opt.units );
-    Print(Length(tst), " ", LowercaseString( opt.units ), "s detected\n");
+    Info(InfoGAPDoc, 1, Length(tst), " ", LowercaseString( opt.units ), "s detected");
     pkgdirString := Filename(pkgdir, "");
 
     # ensure the 'tst' directory exists
@@ -461,9 +461,9 @@ function( pkgname, pkgdir, docdir, main, files, opt )
         number_of_digits := 2;
     fi;
     for i in [ 1 .. Length(tst) ] do
-        Print( opt.units, " ", i, " : \c" );
+        Info(InfoGAPDoc, 1,  opt.units, " ", i, "...");
         if Length( tst[i] ) = 0 then
-            Print("no examples \n" );
+            Info(InfoGAPDoc, 1, "no examples");
             continue;
         fi;
         nonempty_units_found := nonempty_units_found + 1;
@@ -522,6 +522,6 @@ function( pkgname, pkgdir, docdir, main, files, opt )
         AppendTo(output, "#\n");
         AppendTo(output, "gap> STOP_TEST(\"", basename, "\", 1);\n");
         CloseStream( output );
-        Print("extracted ", Length(ch), " examples\n");
+        Info(InfoGAPDoc, 1, "extracted ", Length(ch), " examples");
     od;
 end);

--- a/gap/AutoDocMainFunction.gi
+++ b/gap/AutoDocMainFunction.gi
@@ -285,7 +285,7 @@ InstallGlobalFunction( CreateTitlePage,
                 i := List(i, Int);
                 OutWithTag( "Date", AUTODOC_FormatDate(i[1], i[2], i[3]) );
             else
-                Info(InfoGAPDoc, 1, "Warning: could not parse package date '", argument_rec.Date, "'");
+                Info(InfoAutoDoc, 1, "Warning: could not parse package date '", argument_rec.Date, "'");
                 OutWithTag( "Date", argument_rec.Date );
             fi;
         fi;
@@ -426,7 +426,7 @@ BindGlobal("AUTODOC_ExtractMyManualExamples",
 function( pkgname, pkgdir, docdir, main, files, opt )
     local tst, i, s, basename, name, output, ch, a, location, pos, comment, pkgdirString,
       nonempty_units_found, number_of_digits, lpkgname, tstdir;
-    Info(InfoGAPDoc, 1, "Extracting manual examples for ", pkgname, " package ...");
+    Info(InfoAutoDoc, 1, "Extracting manual examples for ", pkgname, " package ...");
 
     lpkgname := LowercaseString(pkgname);
     lpkgname := ReplacedString(lpkgname, " ", "_");
@@ -435,7 +435,7 @@ function( pkgname, pkgdir, docdir, main, files, opt )
         main := Concatenation( main, ".xml" );
     fi;
     tst:=ExtractExamples( docdir, main, files, opt.units );
-    Info(InfoGAPDoc, 1, Length(tst), " ", LowercaseString( opt.units ), "s detected");
+    Info(InfoAutoDoc, 1, Length(tst), " ", LowercaseString( opt.units ), "s detected");
     pkgdirString := Filename(pkgdir, "");
 
     # ensure the 'tst' directory exists
@@ -461,9 +461,9 @@ function( pkgname, pkgdir, docdir, main, files, opt )
         number_of_digits := 2;
     fi;
     for i in [ 1 .. Length(tst) ] do
-        Info(InfoGAPDoc, 1,  opt.units, " ", i, "...");
+        Info(InfoAutoDoc, 1,  opt.units, " ", i, "...");
         if Length( tst[i] ) = 0 then
-            Info(InfoGAPDoc, 1, "no examples");
+            Info(InfoAutoDoc, 1, "no examples");
             continue;
         fi;
         nonempty_units_found := nonempty_units_found + 1;
@@ -522,6 +522,6 @@ function( pkgname, pkgdir, docdir, main, files, opt )
         AppendTo(output, "#\n");
         AppendTo(output, "gap> STOP_TEST(\"", basename, "\", 1);\n");
         CloseStream( output );
-        Info(InfoGAPDoc, 1, "extracted ", Length(ch), " examples");
+        Info(InfoAutoDoc, 1, "extracted ", Length(ch), " examples");
     od;
 end);

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -401,7 +401,8 @@ DeclareGlobalFunction( "AutoDoc" );
 
 #! @Description
 #!   Info class for the <Package>AutoDoc</Package> package.  Set this to
-#!   0 to suppress info messages, or 1 to allow them.
+#!   0 to suppress info messages, 1 to allow most messages, and 2 to allow all
+#!   messages including those that contain file paths.
 #!
 #!   This can be set by calling, for example,
 #!   <C>SetInfoLevel(InfoPackageManager, 0)</C>. Default value 1.

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -399,6 +399,14 @@
 #! @Arguments [packageOrDirectory], [optrec]
 DeclareGlobalFunction( "AutoDoc" );
 
+#! @Description
+#!   Info class for the <Package>AutoDoc</Package> package.  Set this to
+#!   0 to suppress info messages, or 1 to allow them.
+#!
+#!   This can be set by calling, for example,
+#!   <C>SetInfoLevel(InfoPackageManager, 0)</C>. Default value 1.
+DeclareInfoClass("InfoAutoDoc");
+SetInfoLevel(InfoAutoDoc, 1);
 
 #! @Section Examples
 #!

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -215,7 +215,7 @@ function( arg )
     if IsBound(scaffold) and IsBound( pkginfo.AutoDoc ) then
         for key in RecNames( pkginfo.AutoDoc ) do
             if IsBound( scaffold.(key) ) then
-                Print("WARNING: ", key, " specified in both PackageInfo.AutoDoc and opt.scaffold\n");
+                Info(InfoGAPDoc, 1, key, " specified in both PackageInfo.AutoDoc and opt.scaffold");
             else
                 scaffold.(key) := pkginfo.AutoDoc.(key);
             fi;
@@ -298,7 +298,7 @@ function( arg )
 
         if IsBound( pkginfo.PackageDoc ) and not IsEmpty( pkginfo.PackageDoc ) then
             if Length( pkginfo.PackageDoc ) > 1 then
-                Print("WARNING: Package contains multiple books, only using the first one\n");
+                Info(InfoGAPDoc, 1, "Package contains multiple books, only using the first one");
             fi;
             gapdoc.bookname := pkginfo.PackageDoc[1].BookName;
             gapdoc.SixFile := pkginfo.PackageDoc[1].SixFile;
@@ -307,19 +307,17 @@ function( arg )
             gapdoc.bookname := pkgname;
             gapdoc.SixFile := "doc/manual.six";
 
-            Print("\n");
-            Print("WARNING: PackageInfo.g is missing a PackageDoc entry!\n");
-            Print("Without this, your package manual will not be recognized by the GAP help system.\n");
-            Print("You can correct this by adding the following to your PackageInfo.g:\n");
-            Print("PackageDoc := rec(\n");
-            Print("  BookName  := ~.PackageName,\n");
-            Print("  ArchiveURLSubset := [\"doc\"],\n");
-            Print("  HTMLStart := \"doc/chap0.html\",\n");
-            Print("  PDFFile   := \"doc/manual.pdf\",\n");
-            Print("  SixFile   := \"doc/manual.six\",\n");
-            Print("  LongTitle := ~.Subtitle,\n");
-            Print("),\n");
-            Print("\n");
+            Info(InfoGAPDoc, 1, "WARNING: PackageInfo.g is missing a PackageDoc entry!");
+            Info(InfoGAPDoc, 1, "Without this, your package manual will not be recognized by the GAP help system.");
+            Info(InfoGAPDoc, 1, "You can correct this by adding the following to your PackageInfo.g:");
+            Info(InfoGAPDoc, 1, "PackageDoc := rec(");
+            Info(InfoGAPDoc, 1, "  BookName  := ~.PackageName,");
+            Info(InfoGAPDoc, 1, "  ArchiveURLSubset := [\"doc\"],");
+            Info(InfoGAPDoc, 1, "  HTMLStart := \"doc/chap0.html\",");
+            Info(InfoGAPDoc, 1, "  PDFFile   := \"doc/manual.pdf\",");
+            Info(InfoGAPDoc, 1, "  SixFile   := \"doc/manual.six\",");
+            Info(InfoGAPDoc, 1, "  LongTitle := ~.Subtitle,");
+            Info(InfoGAPDoc, 1, "),");
         fi;
 
         if not IsBound( gapdoc.files ) then

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -215,7 +215,7 @@ function( arg )
     if IsBound(scaffold) and IsBound( pkginfo.AutoDoc ) then
         for key in RecNames( pkginfo.AutoDoc ) do
             if IsBound( scaffold.(key) ) then
-                Info(InfoGAPDoc, 1, key, " specified in both PackageInfo.AutoDoc and opt.scaffold");
+                Info(InfoGAPDoc, 1, "WARNING: ", key, " specified in both PackageInfo.AutoDoc and opt.scaffold");
             else
                 scaffold.(key) := pkginfo.AutoDoc.(key);
             fi;
@@ -298,7 +298,7 @@ function( arg )
 
         if IsBound( pkginfo.PackageDoc ) and not IsEmpty( pkginfo.PackageDoc ) then
             if Length( pkginfo.PackageDoc ) > 1 then
-                Info(InfoGAPDoc, 1, "Package contains multiple books, only using the first one");
+                Info(InfoGAPDoc, 1, "WARNING: Package contains multiple books, only using the first one");
             fi;
             gapdoc.bookname := pkginfo.PackageDoc[1].BookName;
             gapdoc.SixFile := pkginfo.PackageDoc[1].SixFile;

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -190,7 +190,7 @@ function( arg )
     # This helps diagnose problems where multiple instances of a package
     # are visible to GAP and the wrong one is used for generating the
     # documentation.
-    Info( InfoAutoDoc, 1, "Generating documentation in ", doc_dir, "\n" );
+    Info( InfoAutoDoc, 1, "Generating documentation in ", doc_dir);
 
     #
     # Extract scaffolding settings, which can be controlled via

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -190,7 +190,7 @@ function( arg )
     # This helps diagnose problems where multiple instances of a package
     # are visible to GAP and the wrong one is used for generating the
     # documentation.
-    Info( InfoAutoDoc, 1, "Generating documentation in ", doc_dir);
+    Info( InfoAutoDoc, 2, "Generating documentation in ", doc_dir);
 
     #
     # Extract scaffolding settings, which can be controlled via

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -190,7 +190,7 @@ function( arg )
     # This helps diagnose problems where multiple instances of a package
     # are visible to GAP and the wrong one is used for generating the
     # documentation.
-    Info( InfoGAPDoc, 1, "Generating documentation in ", doc_dir, "\n" );
+    Info( InfoAutoDoc, 1, "Generating documentation in ", doc_dir, "\n" );
 
     #
     # Extract scaffolding settings, which can be controlled via
@@ -215,7 +215,7 @@ function( arg )
     if IsBound(scaffold) and IsBound( pkginfo.AutoDoc ) then
         for key in RecNames( pkginfo.AutoDoc ) do
             if IsBound( scaffold.(key) ) then
-                Info(InfoGAPDoc, 1, "WARNING: ", key, " specified in both PackageInfo.AutoDoc and opt.scaffold");
+                Info(InfoAutoDoc, 1, "WARNING: ", key, " specified in both PackageInfo.AutoDoc and opt.scaffold");
             else
                 scaffold.(key) := pkginfo.AutoDoc.(key);
             fi;
@@ -298,7 +298,7 @@ function( arg )
 
         if IsBound( pkginfo.PackageDoc ) and not IsEmpty( pkginfo.PackageDoc ) then
             if Length( pkginfo.PackageDoc ) > 1 then
-                Info(InfoGAPDoc, 1, "WARNING: Package contains multiple books, only using the first one");
+                Info(InfoAutoDoc, 1, "WARNING: Package contains multiple books, only using the first one");
             fi;
             gapdoc.bookname := pkginfo.PackageDoc[1].BookName;
             gapdoc.SixFile := pkginfo.PackageDoc[1].SixFile;
@@ -307,17 +307,17 @@ function( arg )
             gapdoc.bookname := pkgname;
             gapdoc.SixFile := "doc/manual.six";
 
-            Info(InfoGAPDoc, 1, "WARNING: PackageInfo.g is missing a PackageDoc entry!");
-            Info(InfoGAPDoc, 1, "Without this, your package manual will not be recognized by the GAP help system.");
-            Info(InfoGAPDoc, 1, "You can correct this by adding the following to your PackageInfo.g:");
-            Info(InfoGAPDoc, 1, "PackageDoc := rec(");
-            Info(InfoGAPDoc, 1, "  BookName  := ~.PackageName,");
-            Info(InfoGAPDoc, 1, "  ArchiveURLSubset := [\"doc\"],");
-            Info(InfoGAPDoc, 1, "  HTMLStart := \"doc/chap0.html\",");
-            Info(InfoGAPDoc, 1, "  PDFFile   := \"doc/manual.pdf\",");
-            Info(InfoGAPDoc, 1, "  SixFile   := \"doc/manual.six\",");
-            Info(InfoGAPDoc, 1, "  LongTitle := ~.Subtitle,");
-            Info(InfoGAPDoc, 1, "),");
+            Info(InfoAutoDoc, 1, "WARNING: PackageInfo.g is missing a PackageDoc entry!");
+            Info(InfoAutoDoc, 1, "Without this, your package manual will not be recognized by the GAP help system.");
+            Info(InfoAutoDoc, 1, "You can correct this by adding the following to your PackageInfo.g:");
+            Info(InfoAutoDoc, 1, "PackageDoc := rec(");
+            Info(InfoAutoDoc, 1, "  BookName  := ~.PackageName,");
+            Info(InfoAutoDoc, 1, "  ArchiveURLSubset := [\"doc\"],");
+            Info(InfoAutoDoc, 1, "  HTMLStart := \"doc/chap0.html\",");
+            Info(InfoAutoDoc, 1, "  PDFFile   := \"doc/manual.pdf\",");
+            Info(InfoAutoDoc, 1, "  SixFile   := \"doc/manual.six\",");
+            Info(InfoAutoDoc, 1, "  LongTitle := ~.Subtitle,");
+            Info(InfoAutoDoc, 1, "),");
         fi;
 
         if not IsBound( gapdoc.files ) then

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -139,7 +139,7 @@ function( message )
     x := true;
     return function( )
         if x then
-            Info( InfoGAPDoc, 1, message );
+            Info( InfoAutoDoc, 1, message );
         fi;
         x := false;
     end;
@@ -201,10 +201,10 @@ function(ws)
     filenames := Filtered(filenames, f -> f <> "." and f <> "..");
     filenames := List(filenames, f -> Filename(sheetdir, f));
 
-    old := InfoLevel(InfoGAPDoc);
-    SetInfoLevel(InfoGAPDoc, 0);
+    old := InfoLevel(InfoAutoDoc);
+    SetInfoLevel(InfoAutoDoc, 0);
     AutoDocWorksheet(filenames, rec(dir := actualdir, extract_examples := true));
-    SetInfoLevel(InfoGAPDoc, old);
+    SetInfoLevel(InfoAutoDoc, old);
 
     # Check the results
     filenames := DirectoryContents(expecteddir);

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -133,13 +133,13 @@ InstallGlobalFunction( AutoDoc_WriteDocEntry,
 end );
 
 InstallGlobalFunction( AutoDoc_CreatePrintOnceFunction,
-  function( message )
+function( message )
     local x;
     
     x := true;
     return function( )
         if x then
-            Print( message, "\n" );
+            Info( InfoGAPDoc, 1, message );
         fi;
         x := false;
     end;

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -201,10 +201,10 @@ function(ws)
     filenames := Filtered(filenames, f -> f <> "." and f <> "..");
     filenames := List(filenames, f -> Filename(sheetdir, f));
 
-    old := InfoLevel(InfoAutoDoc);
-    SetInfoLevel(InfoAutoDoc, 0);
+    old := InfoLevel(InfoGAPDoc);
+    SetInfoLevel(InfoGAPDoc, 0);
     AutoDocWorksheet(filenames, rec(dir := actualdir, extract_examples := true));
-    SetInfoLevel(InfoAutoDoc, old);
+    SetInfoLevel(InfoGAPDoc, old);
 
     # Check the results
     filenames := DirectoryContents(expecteddir);

--- a/tst/dogfood.tst
+++ b/tst/dogfood.tst
@@ -31,7 +31,6 @@ true
 
 # regenerate the manual using AutoDoc
 gap> Read("makedoc.g");
-#I  Generating documentation in Directory("/home/mtorpey/.gap/pkg/AutoDoc/doc/")
 
 # restore info levels and current directory
 gap> SetInfoLevel( InfoGAPDoc, oldGAPDocLevel );

--- a/tst/dogfood.tst
+++ b/tst/dogfood.tst
@@ -31,6 +31,7 @@ true
 
 # regenerate the manual using AutoDoc
 gap> Read("makedoc.g");
+#I  Generating documentation in Directory("/home/mtorpey/.gap/pkg/AutoDoc/doc/")
 
 # restore info levels and current directory
 gap> SetInfoLevel( InfoGAPDoc, oldGAPDocLevel );

--- a/tst/manual.expected/_Chapter_AutoDoc.xml
+++ b/tst/manual.expected/_Chapter_AutoDoc.xml
@@ -361,7 +361,8 @@
   <InfoClass Name="InfoAutoDoc" />
  <Description>
    Info class for the <Package>AutoDoc</Package> package.  Set this to
-   0 to suppress info messages, or 1 to allow them.
+   0 to suppress info messages, 1 to allow most messages, and 2 to allow all
+   messages including those that contain file paths.
 <P/>
    This can be set by calling, for example,
    <C>SetInfoLevel(InfoPackageManager, 0)</C>. Default value 1.

--- a/tst/manual.expected/_Chapter_AutoDoc.xml
+++ b/tst/manual.expected/_Chapter_AutoDoc.xml
@@ -357,6 +357,18 @@
 </ManSection>
 
 
+<ManSection>
+  <InfoClass Name="InfoAutoDoc" />
+ <Description>
+   Info class for the <Package>AutoDoc</Package> package.  Set this to
+   0 to suppress info messages, or 1 to allow them.
+<P/>
+   This can be set by calling, for example,
+   <C>SetInfoLevel(InfoPackageManager, 0)</C>. Default value 1.
+ </Description>
+</ManSection>
+
+
 </Section>
 
 

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,4 +1,5 @@
 LoadPackage( "AutoDoc" );
 SetInfoLevel(InfoAutoDoc, 1);
+SetInfoLevel(InfoGAPDoc, 0);
 TestDirectory( DirectoriesPackageLibrary("AutoDoc", "tst"), rec(exitGAP := true ) );
 FORCE_QUIT_GAP(1);

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,3 +1,4 @@
 LoadPackage( "AutoDoc" );
+SetInfoLevel(InfoAutoDoc, 0);
 TestDirectory( DirectoriesPackageLibrary("AutoDoc", "tst"), rec(exitGAP := true ) );
 FORCE_QUIT_GAP(1);

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,4 +1,4 @@
 LoadPackage( "AutoDoc" );
-SetInfoLevel(InfoAutoDoc, 0);
+SetInfoLevel(InfoAutoDoc, 1);
 TestDirectory( DirectoriesPackageLibrary("AutoDoc", "tst"), rec(exitGAP := true ) );
 FORCE_QUIT_GAP(1);

--- a/tst/worksheets.tst
+++ b/tst/worksheets.tst
@@ -5,53 +5,9 @@ gap> START_TEST( "worksheets.tst" );
 
 #
 gap> AUTODOC_TestWorkSheet("general");
-#I Composing XML document . . .
-#I Parsing XML document . . .
-#I Checking XML structure . . .
-#I Text version (also produces labels for hyperlinks):
-#I First run, collecting cross references, index, toc, bib and so on . . .
-#I Table of contents complete.
-#I Producing the index . . .
-#I Second run through document . . .
-#I Producing simplified search strings and labels for hyperlinks . . .
-#I Constructing LaTeX version and calling pdflatex:
-#I Writing LaTeX file, 4 x pdflatex with bibtex and makeindex, 
-#I Writing manual.six file ... 
-#I Finally the HTML version . . .
-#I First run, collecting cross references, index, toc, bib and so on . . .
-#I Table of contents complete.
-#I Producing the index . . .
-#I Second run through document . . .
-#I - also HTML version for MathJax . . .
-#I First run, collecting cross references, index, toc, bib and so on . . .
-#I Table of contents complete.
-#I Producing the index . . .
-#I Second run through document . . .
 
 #
 gap> AUTODOC_TestWorkSheet("autoplain");
-#I Composing XML document . . .
-#I Parsing XML document . . .
-#I Checking XML structure . . .
-#I Text version (also produces labels for hyperlinks):
-#I First run, collecting cross references, index, toc, bib and so on . . .
-#I Table of contents complete.
-#I Producing the index . . .
-#I Second run through document . . .
-#I Producing simplified search strings and labels for hyperlinks . . .
-#I Constructing LaTeX version and calling pdflatex:
-#I Writing LaTeX file, 4 x pdflatex with bibtex and makeindex, 
-#I Writing manual.six file ... 
-#I Finally the HTML version . . .
-#I First run, collecting cross references, index, toc, bib and so on . . .
-#I Table of contents complete.
-#I Producing the index . . .
-#I Second run through document . . .
-#I - also HTML version for MathJax . . .
-#I First run, collecting cross references, index, toc, bib and so on . . .
-#I Table of contents complete.
-#I Producing the index . . .
-#I Second run through document . . .
 
 #
 #

--- a/tst/worksheets.tst
+++ b/tst/worksheets.tst
@@ -5,9 +5,53 @@ gap> START_TEST( "worksheets.tst" );
 
 #
 gap> AUTODOC_TestWorkSheet("general");
+#I Composing XML document . . .
+#I Parsing XML document . . .
+#I Checking XML structure . . .
+#I Text version (also produces labels for hyperlinks):
+#I First run, collecting cross references, index, toc, bib and so on . . .
+#I Table of contents complete.
+#I Producing the index . . .
+#I Second run through document . . .
+#I Producing simplified search strings and labels for hyperlinks . . .
+#I Constructing LaTeX version and calling pdflatex:
+#I Writing LaTeX file, 4 x pdflatex with bibtex and makeindex, 
+#I Writing manual.six file ... 
+#I Finally the HTML version . . .
+#I First run, collecting cross references, index, toc, bib and so on . . .
+#I Table of contents complete.
+#I Producing the index . . .
+#I Second run through document . . .
+#I - also HTML version for MathJax . . .
+#I First run, collecting cross references, index, toc, bib and so on . . .
+#I Table of contents complete.
+#I Producing the index . . .
+#I Second run through document . . .
 
 #
 gap> AUTODOC_TestWorkSheet("autoplain");
+#I Composing XML document . . .
+#I Parsing XML document . . .
+#I Checking XML structure . . .
+#I Text version (also produces labels for hyperlinks):
+#I First run, collecting cross references, index, toc, bib and so on . . .
+#I Table of contents complete.
+#I Producing the index . . .
+#I Second run through document . . .
+#I Producing simplified search strings and labels for hyperlinks . . .
+#I Constructing LaTeX version and calling pdflatex:
+#I Writing LaTeX file, 4 x pdflatex with bibtex and makeindex, 
+#I Writing manual.six file ... 
+#I Finally the HTML version . . .
+#I First run, collecting cross references, index, toc, bib and so on . . .
+#I Table of contents complete.
+#I Producing the index . . .
+#I Second run through document . . .
+#I - also HTML version for MathJax . . .
+#I First run, collecting cross references, index, toc, bib and so on . . .
+#I Table of contents complete.
+#I Producing the index . . .
+#I Second run through document . . .
 
 #
 #

--- a/tst/worksheets.tst
+++ b/tst/worksheets.tst
@@ -5,16 +5,9 @@ gap> START_TEST( "worksheets.tst" );
 
 #
 gap> AUTODOC_TestWorkSheet("general");
-Extracting manual examples for General Test package ...
-2 chapters detected
-Chapter 1 : extracted 2 examples
-Chapter 2 : no examples 
 
 #
 gap> AUTODOC_TestWorkSheet("autoplain");
-Extracting manual examples for Plain file.autodoc Test package ...
-1 chapters detected
-Chapter 1 : extracted 2 examples
 
 #
 #

--- a/tst/worksheets.tst
+++ b/tst/worksheets.tst
@@ -5,9 +5,19 @@ gap> START_TEST( "worksheets.tst" );
 
 #
 gap> AUTODOC_TestWorkSheet("general");
+#I  Extracting manual examples for General Test package ...
+#I  2 chapters detected
+#I  Chapter 1...
+#I  extracted 2 examples
+#I  Chapter 2...
+#I  no examples
 
 #
 gap> AUTODOC_TestWorkSheet("autoplain");
+#I  Extracting manual examples for Plain file.autodoc Test package ...
+#I  1 chapters detected
+#I  Chapter 1...
+#I  extracted 2 examples
 
 #
 #


### PR DESCRIPTION
In various places, AutoDoc uses `Print` to print status messages, with no way to silence these.  This is a bit annoying in automated workflows like the package manager.

This PR adds a new info class `InfoAutoDoc` which is used instead of `Print`.  It's currently binary: 1 for messages and 0 for no messages.  The default is 1, of course.