### PR TITLE
Potential fix for `InstallMethod` in first line of GAP source file leading to an error

### DIFF
--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -827,6 +827,8 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
     ##Now read the files.
     for filename in filename_list do
         Reset();
+        ##Need to set autodoc_read_line to false again since we now look at a new file.
+        autodoc_read_line := false;
         ## FIXME: Is this dangerous?
         if PositionSublist( filename, ".autodoc" ) <> fail then
             plain_text_mode := true;


### PR DESCRIPTION
Addresses gap-packages#290. According to my understanding, the problem comes from the variable `autodoc_read_line` not being reset when re-entering the loop with a new file, which later leads to `Scan_for_Declaration_part()` being called when it shouldn't.

This should potentially fix it. I haven't tested it too thoroughly, but on my system I can now build the docs without an error.