### PR TITLE
tests: support read-only package directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ This file describes changes in the AutoDoc package.
 
 2026.MM.DD
   - Fix `InstallMethod` in first line of GAP source file leading to an error
+  - Make tests work when the package directory is read-only by writing
+    generated test output to temporary directories
 
 2025.12.19
   - Don't replace empty lines in `@BeginCode` blocks by `<P/>`

--- a/gap/ToolFunctions.gi
+++ b/gap/ToolFunctions.gi
@@ -161,13 +161,13 @@ end);
 # `tst/worksheets/<ws>.expected` a directory containing the output of
 # AutoDocWorksheet for that worksheet.
 #
-# Then AUTODOC_TestWorkSheet will again run AutoDocWorksheet, put storing the
-# output into `tst/worksheets/<ws>.actual`; it then runs diff on all files in
-# order to find any differences that may have crept in. If no differences
-# exist, it outputs nothing.
+# Then AUTODOC_TestWorkSheet will again run AutoDocWorksheet, storing the
+# output in a temporary directory; it then runs diff on all files in order to
+# find any differences that may have crept in. If no differences exist, it
+# outputs nothing.
 InstallGlobalFunction( AUTODOC_TestWorkSheet,
 function(ws)
-    local wsdir, sheetdir, expecteddir, actualdir, filenames, old, f, expected, actual;
+    local wsdir, sheetdir, expecteddir, actualdir, filenames, old, f, expected, actual, tmpdir;
 
     # check worksheets dir exists
     wsdir := DirectoriesPackageLibrary("AutoDoc", "tst/worksheets");
@@ -190,10 +190,13 @@ function(ws)
     fi;
     expecteddir := Directory(expecteddir);
 
-    # create and clear the output directory
-    actualdir := Filename(wsdir, Concatenation(ws, ".actual"));
-    Exec(Concatenation("rm -rf \"", actualdir, "\""));
-    AUTODOC_CreateDirIfMissing(actualdir);
+    # create and clear the output directory in a writable temporary location
+    tmpdir := Filename(DirectoryTemporary(), Concatenation("autodoc-", ws, ".actual"));
+    if IsDirectoryPath(tmpdir) then
+      RemoveDirectoryRecursively(tmpdir);
+    fi;
+    AUTODOC_CreateDirIfMissing(tmpdir);
+    actualdir := tmpdir;
     actualdir := Directory(actualdir);
 
     # Run the worksheet
@@ -216,6 +219,8 @@ function(ws)
             Error("diff detected in file ", f);
         fi;
     od;
+
+    RemoveDirectoryRecursively(tmpdir);
 end);
 
 # Parse a date given as a string. Currently only supports the two formats

--- a/tst/dogfood.tst
+++ b/tst/dogfood.tst
@@ -23,10 +23,15 @@ gap> oldWarningLevel := InfoLevel( InfoWarning );;
 gap> SetInfoLevel( InfoGAPDoc, 0 );
 gap> SetInfoLevel( InfoWarning, 0 );
 
-# change into the package directory
+# prepare a temporary package copy and run there
 gap> olddir := AUTODOC_CurrentDirectory();;
 gap> pkgdir := DirectoriesPackageLibrary( "AutoDoc", "");;
-gap> ChangeDirectoryCurrent(Filename(pkgdir, ""));
+
+# run in a temporary copy, so the package source tree can stay read-only
+gap> tempdir := Filename(DirectoryTemporary(), "autodoc-dogfood");;
+gap> if IsDirectoryPath(tempdir) then RemoveDirectoryRecursively(tempdir); fi;
+gap> Exec(Concatenation("cp -R \"", Filename(pkgdir, ""), "\" \"", tempdir, "\""));
+gap> ChangeDirectoryCurrent(tempdir);
 true
 
 # regenerate the manual using AutoDoc
@@ -40,7 +45,7 @@ true
 
 # prepare to compare the output to the reference output
 # No point in testing chapters 1 or 2 unless/until they are converted to autodoc
-gap> docdir := DirectoriesPackageLibrary( "AutoDoc", "doc" );;
+gap> docdir := Directory(Concatenation(tempdir, "/doc"));;
 gap> ex_dir := DirectoriesPackageLibrary( "AutoDoc", "tst/manual.expected" );;
 
 # check chapter 3
@@ -54,6 +59,10 @@ gap> chap4 := Filename( docdir, "_Chapter_AutoDoc.xml" );;
 gap> chap4ref := Filename( ex_dir, "_Chapter_AutoDoc.xml" );;
 gap> AUTODOC_Diff("-u", chap4ref, chap4);
 0
+
+#
+gap> RemoveDirectoryRecursively(tempdir);
+true
 
 #
 gap> STOP_TEST( "dogfood.tst" );


### PR DESCRIPTION
Write generated worksheet and dogfood test output to temporary
directories so tests no longer need package tree write access.

Resolves #281

Co-authored-by: Codex <codex@openai.com>
