### PR TITLE
parser: remove DONT_SCAN_NEXT_LINE shebang hack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ This file describes changes in the AutoDoc package.
   - Fix `InstallMethod` in first line of GAP source file leading to an error
   - Make tests work when the package directory is read-only by writing
     generated test output to temporary directories
+  - Remove `@DONT_SCAN_NEXT_LINE` parser hack and only treat `#!` as an
+    AutoDoc marker at the start of a line (ignoring leading whitespace)
 
 2025.12.19
   - Don't replace empty lines in `@BeginCode` blocks by `<P/>`

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -63,4 +63,26 @@ Error, <year> must be an integer >= 2000, or a string representing such an int\
 eger
 
 #
+# AUTODOC_PositionPrefixShebang
+#
+gap> AUTODOC_PositionPrefixShebang( "#! @Chapter Intro" );
+1
+gap> AUTODOC_PositionPrefixShebang( "   #! @Section One" );
+4
+gap> AUTODOC_PositionPrefixShebang( "\t#! @Subsection Two" );
+2
+gap> AUTODOC_PositionPrefixShebang( "" );
+fail
+gap> AUTODOC_PositionPrefixShebang( "#" );
+fail
+gap> AUTODOC_PositionPrefixShebang( "    " );
+fail
+gap> AUTODOC_PositionPrefixShebang( "x #! @Chapter NotPrefix" );
+fail
+gap> AUTODOC_PositionPrefixShebang( "  x#! @Chapter NotPrefix" );
+fail
+gap> AUTODOC_PositionPrefixShebang( "  # ! not-a-shebang" );
+fail
+
+#
 gap> STOP_TEST( "misc.tst" );


### PR DESCRIPTION
Use one helper for shebang detection in parser paths. Accept #! only at line start after leading whitespace.

Co-authored-by: Codex <codex@openai.com>

Resolves #126