### PR TITLE
Improve manual docs for XML in AutoDoc comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 This file describes changes in the AutoDoc package.
 
 2026.MM.DD
+  - Greatly improve the package manual.
   - Fix `InstallMethod` in first line of GAP source file leading to an error
   - Make tests work when the package directory is read-only by writing
     generated test output to temporary directories

--- a/doc/Comments.xml
+++ b/doc/Comments.xml
@@ -25,6 +25,18 @@ block and the <C>Declare...</C> statement.
 
 Inside of &AutoDoc; comments, <E>&AutoDoc; commands</E>
 starting with <C>@</C> can be used to control the output &AutoDoc; produces.
+Any comment line that does <E>not</E> start with an &AutoDoc; command is treated
+as regular documentation text and may contain (almost) arbitrary &GAPDoc; XML
+markup, such as <C>&lt;Ref&gt;</C>, <C>&lt;A&gt;</C>, <C>&lt;List&gt;</C>, and similar tags.
+This lets you use the normal &GAPDoc; formatting toolbox directly inside
+&AutoDoc; comments.
+<P/>
+For example:
+<Listing><![CDATA[
+#! @Description
+#!  See <Ref Chap="Tutorials"/> for setup details.
+#!  The argument <A>obj</A> must satisfy <K>IsObject</K>.
+]]></Listing>
 
 <P/>
 As explained in chapter <Ref Chap="Overview"/>, you can combine &AutoDoc;

--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -130,6 +130,12 @@ it documents. Do not place other code between the comment block and the
 DeclareOperation( "ToricVariety", [ IsConvexObject ] );
 ]]></Listing>
 
+In these comment lines, you can freely use normal &GAPDoc; XML markup
+(with the usual exceptions for lines starting with <C>@</C>, which are
+interpreted as &AutoDoc; commands). So, for instance, tags like
+<C>&lt;Ref&gt;</C>, <C>&lt;A&gt;</C>, <C>&lt;K&gt;</C>, <C>&lt;List&gt;</C>, etc. can be written
+directly in <C>#!</C> comment text.
+
 For a thorough description of what you can do with &AutoDoc;
 documentation comments, please refer to chapter <Ref Chap="Comments"/>.
 <P/>


### PR DESCRIPTION
Document that comment text can use GAPDoc XML tags. Also add a changelog note about major manual improvements.

Co-authored-by: Codex <codex@openai.com>

Resolves #131