### PR TITLE
Fix multiline `InstallMethod` parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ This file describes changes in the AutoDoc package.
 
 2026.MM.DD
   - Fix `InstallMethod` in first line of GAP source file leading to an error
+  - Fix multiline `InstallMethod` parsing for filter lists and
+    multiline `function(...)` argument lists
   - Make tests work when the package directory is read-only by writing
     generated test output to temporary directories
   - Remove `@DONT_SCAN_NEXT_LINE` parser hack and only treat `#!` as an

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -381,8 +381,12 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             position_parenthesis := AUTODOC_PositionElementIfNotAfter( current_line, '[', '\\' );
             current_line := current_line{[ position_parenthesis + 1 .. Length( current_line ) ]};
             filter_string := "for ";
-            while PositionSublist( current_line, "]" ) = fail do
+            while AUTODOC_PositionElementIfNotAfter( current_line, ']', '\\' ) = fail do
                 Append( filter_string, current_line );
+                current_line := Normalized_ReadLine( filestream );
+                if current_line = fail then
+                    ErrorWithPos( "unterminated InstallMethod filter list" );
+                fi;
             od;
             position_parenthesis := AUTODOC_PositionElementIfNotAfter( current_line, ']', '\\' );
             Append( filter_string, current_line{[ 1 .. position_parenthesis - 1 ]} );
@@ -403,10 +407,13 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                 if position_parenthesis <> fail then
                     current_line := current_line{[ position_parenthesis + 9 .. Length( current_line ) ]};
                     filter_string := "";
-                    while PositionSublist( current_line, ")" ) = fail do;
+                    while PositionSublist( current_line, ")" ) = fail do
                         current_line := StripBeginEnd( current_line, " " );
                         Append( filter_string, current_line );
-                        current_line := Normalized_ReadLine( current_line );
+                        current_line := Normalized_ReadLine( filestream );
+                        if current_line = fail then
+                            ErrorWithPos( "unterminated argument list in InstallMethod declaration" );
+                        fi;
                     od;
                     position_parenthesis := PositionSublist( current_line, ")" );
                     Append( filter_string, current_line{[ 1 .. position_parenthesis - 1 ]} );

--- a/tst/autodoc-parser-installmethod.g
+++ b/tst/autodoc-parser-installmethod.g
@@ -1,0 +1,10 @@
+#! @Chapter Parser
+#! @Section InstallMethod
+InstallMethod( "MyOp",
+               [ IsInt,
+                 IsString ],
+function(
+    x,
+    y )
+  return x;
+end );

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -85,4 +85,20 @@ gap> AUTODOC_PositionPrefixShebang( "  # ! not-a-shebang" );
 fail
 
 #
+# AutoDoc_Parser_ReadFiles: multiline InstallMethod parsing
+#
+gap> tree := DocumentationTree();;
+gap> AutoDoc_Parser_ReadFiles( [ "tst/autodoc-parser-installmethod.g" ], tree, rec() );
+gap> section := SectionInTree( tree, "Parser", "InstallMethod" );;
+gap> item := section!.content[ 1 ];;
+gap> item!.item_type;
+"Oper"
+gap> item!.name;
+"\"MyOp\""
+gap> item!.tester_names;
+"for IsInt,IsString"
+gap> item!.arguments;
+"x,y"
+
+#
 gap> STOP_TEST( "misc.tst" );


### PR DESCRIPTION
Read additional lines while parsing method filters and multiline function argument lists.

Add a misc.tst regression that exercises both multiline InstallMethod filters and multiline function(...) signatures.

Co-authored-by: Codex <codex@openai.com>
