### PR TITLE
Refactor parser command splitting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ This file describes changes in the AutoDoc package.
   - Fix `InstallMethod` in first line of GAP source file leading to an error
   - Fix multiline `InstallMethod` parsing for filter lists and
     multiline `function(...)` argument lists
+  - Make AutoDoc command parsing more robust in plain-text mode when
+    `@Command` does not start at column 1
   - Make tests work when the package directory is read-only by writing
     generated test output to temporary directories
   - Remove `@DONT_SCAN_NEXT_LINE` parser hack and only treat `#!` as an

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -85,6 +85,18 @@ gap> AUTODOC_PositionPrefixShebang( "  # ! not-a-shebang" );
 fail
 
 #
+# Scan_for_AutoDoc_Part: robust command splitting
+#
+gap> Scan_for_AutoDoc_Part( "plain text @Section   Intro", true );
+[ "@Section", "Intro" ]
+gap> Scan_for_AutoDoc_Part( "   @Chapter   My Chapter", true );
+[ "@Chapter", "My Chapter" ]
+gap> Scan_for_AutoDoc_Part( "   @NoArg", true );
+[ "@NoArg", "" ]
+gap> Scan_for_AutoDoc_Part( "no command here", true );
+[ "STRING", "no command here" ]
+
+#
 # AutoDoc_Parser_ReadFiles: multiline InstallMethod parsing
 #
 gap> tree := DocumentationTree();;


### PR DESCRIPTION
Add a dedicated command/argument splitter and use it in `Scan_for_AutoDoc_Part`.

Refactor `InstallMethod` parsing into local helper functions and remove unused parser locals.

Add misc.tst coverage for plain-text command splitting.

Co-authored-by: Codex <codex@openai.com>
