### PR TITLE
docs: improve AutoDoc TitlePage documentation

### DIFF
--- a/doc/Tutorials.xml
+++ b/doc/Tutorials.xml
@@ -554,17 +554,32 @@ and text versions of the manual.
 </Item>
 
 <Mark>AutoDoc</Mark><Item>
-This is a record which can be used to control the scaffolding performed by
-&AutoDoc;, specifically to provide extra information for the title page. For
-example, you can set <C>AutoDoc.TitlePage.Copyright</C> to a string which will
-then be inserted on the generated title page. Using this method you can
-customize the following title page elements: <C>TitleComment</C>,
-<C>Abstract</C>, <C>Copyright</C>, <C>Acknowledgements</C> and <C>Colophon</C>.
+This record controls extra settings used by &AutoDoc; while generating the
+manual. In particular, <C>PkgInfo.AutoDoc.TitlePage</C> lets you add or
+override title-page elements coming from package metadata.
 
 <P/>
-Note that <C>AutoDoc.TitlePage</C> behaves exactly the same
-as the <C>scaffold.TitlePage</C> parameter of the <Ref Func="AutoDoc"/>
-function.
+Typical fields you may set there include <C>TitleComment</C>,
+<C>Abstract</C>, <C>Copyright</C>, <C>Acknowledgements</C> and <C>Colophon</C>.
+For example, in <F>PackageInfo.g</F>:
+<Listing><![CDATA[
+SetPackageInfo( rec(
+  ...
+  AutoDoc := rec(
+    TitlePage := rec(
+      Copyright := "(C) 2026 Jane Doe",
+      Acknowledgements := "Funded by Example Grant 1234."
+    )
+  )
+) );
+]]></Listing>
+This inserts <C>&lt;Copyright></C> and <C>&lt;Acknowledgements></C> blocks into
+the generated <F>title.xml</F>.
+
+<P/>
+<C>PkgInfo.AutoDoc.TitlePage</C> has exactly the same meaning as
+<C>scaffold.TitlePage</C> in <Ref Func="AutoDoc"/>. The function documentation
+for <C>scaffold.TitlePage</C> points back to this subsection.
 </Item>
 
 </List>

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -181,16 +181,18 @@
 #!
 #!         <Mark><A>TitlePage</A></Mark>
 #!         <Item>
-#!             A record whose entries are used to embellish the generated title page
-#!             for the package manual with extra information, such as a copyright
-#!             statement or acknowledgments. To this end, the names of the record
-#!             components are used as XML element names, and the values of the
-#!             components are output as content of these XML elements. For
-#!             example, you could pass the following record to set a custom
-#!             acknowledgements text:
+#!             A record with extra title-page fields for the generated manual.
+#!             Field names are interpreted as title-page XML element names, and
+#!             their values are written as element content. For example, you can
+#!             set a custom acknowledgements block with
 #!             <Listing><![CDATA[
 #!             rec( Acknowledgements := "Many thanks to ..." )]]></Listing>
-#!             For a list of valid entries in the title page, please refer to the
+#!             If this is set in <F>PackageInfo.g</F> as
+#!             <C>PkgInfo.AutoDoc.TitlePage</C>, it has the same meaning as this
+#!             option; see subsection <Ref Subsect='Tut:PackageInfo'/> in chapter
+#!             <Ref Chap='Tutorials'/> for details and an example.
+#!             <P/>
+#!             For the list of valid title-page elements, see the
 #!             &GAPDoc; manual, specifically section <Ref Subsect='TitlePage' BookName='gapdoc'/>.
 #!         </Item>
 #!         <Mark><A>MainPage</A></Mark>

--- a/tst/manual.expected/_Chapter_Reference.xml
+++ b/tst/manual.expected/_Chapter_Reference.xml
@@ -206,16 +206,18 @@
          </Item>
          <Mark><A>TitlePage</A></Mark>
          <Item>
-             A record whose entries are used to embellish the generated title page
-             for the package manual with extra information, such as a copyright
-             statement or acknowledgments. To this end, the names of the record
-             components are used as XML element names, and the values of the
-             components are output as content of these XML elements. For
-             example, you could pass the following record to set a custom
-             acknowledgements text:
+             A record with extra title-page fields for the generated manual.
+             Field names are interpreted as title-page XML element names, and
+             their values are written as element content. For example, you can
+             set a custom acknowledgements block with
              <Listing><![CDATA[
              rec( Acknowledgements := "Many thanks to ..." )]]></Listing>
-             For a list of valid entries in the title page, please refer to the
+             If this is set in <F>PackageInfo.g</F> as
+             <C>PkgInfo.AutoDoc.TitlePage</C>, it has the same meaning as this
+             option; see subsection <Ref Subsect='Tut:PackageInfo'/> in chapter
+             <Ref Chap='Tutorials'/> for details and an example.
+             <P/>
+             For the list of valid title-page elements, see the
              &GAPDoc; manual, specifically section <Ref Subsect='TitlePage' BookName='gapdoc'/>.
          </Item>
          <Mark><A>MainPage</A></Mark>


### PR DESCRIPTION
Clarify PkgInfo.AutoDoc.TitlePage behavior, add an example, and
add bidirectional references between this setting and
scaffold.TitlePage.

Resolves #225

Co-authored-by: Codex <codex@openai.com>
