### PR TITLE
Support Markdown heading aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ This file describes changes in the AutoDoc package.
     AutoDoc marker at the start of a line (ignoring leading whitespace)
   - Warn if a chunk is defined (via `@BeginChunk`/`@BeginCode`) but never
     inserted (via `@InsertChunk`/`@InsertCode`)
+  - Allow using Markdown-style headings `#`/`##`/`###` as aliases for
+    `@Chapter`/`@Section`/`@Subsection` in `.autodoc` files and doc comments
 
 2025.12.19
   - Don't replace empty lines in `@BeginCode` blocks by `<P/>`

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -95,6 +95,14 @@ gap> Scan_for_AutoDoc_Part( "   @NoArg", true );
 [ "@NoArg", "" ]
 gap> Scan_for_AutoDoc_Part( "no command here", true );
 [ "STRING", "no command here" ]
+gap> Scan_for_AutoDoc_Part( "# Heading chapter", true );
+[ "@Chapter", "Heading chapter" ]
+gap> Scan_for_AutoDoc_Part( "## Heading section", true );
+[ "@Section", "Heading section" ]
+gap> Scan_for_AutoDoc_Part( "### Heading subsection", true );
+[ "@Subsection", "Heading subsection" ]
+gap> Scan_for_AutoDoc_Part( "  #! ## Comment section", false );
+[ "@Section", "Comment section" ]
 
 #
 # AutoDoc_Parser_ReadFiles: multiline InstallMethod parsing

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -6,6 +6,12 @@
 
 Does AutoDoc have a way to allow that header block not to appear in
 the documentation generated from a <F>.autodoc</F> file like this?
+<Section Label="Chapter_Test_Section_First_Section">
+<Heading>First Section</Heading>
+
+<Subsection Label="Chapter_Test_Section_First_Section_Subsection_First_Subsection">
+<Heading>First Subsection</Heading>
+
 <Example><![CDATA[
 gap> S5 := SymmetricGroup(5);
 Sym( [ 1 .. 5 ] )
@@ -24,5 +30,11 @@ gap> Size(A5);
 
 
 And we wrap up with some dummy text
+</Subsection>
+
+
+</Section>
+
+
 </Chapter>
 

--- a/tst/worksheets/autoplain.expected/tst/plain_file.autodoc_test01.tst
+++ b/tst/worksheets/autoplain.expected/tst/plain_file.autodoc_test01.tst
@@ -10,13 +10,13 @@
 #
 gap> START_TEST("plain_file.autodoc_test01.tst");
 
-# _Chapter_Test.xml:9-14
+# _Chapter_Test.xml:15-20
 gap> S5 := SymmetricGroup(5);
 Sym( [ 1 .. 5 ] )
 gap> Size(S5);
 120
 
-# _Chapter_Test.xml:18-23
+# _Chapter_Test.xml:24-29
 gap> A5 := AlternatingGroup(5);
 Alt( [ 1 .. 5 ] )
 gap> Size(A5);

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -1,9 +1,11 @@
 @Title Plain file.autodoc Test
 @Date 2018-08-30
 
-@Chapter Test
+# Test
 Does AutoDoc have a way to allow that header block not to appear in
 the documentation generated from a <F>.autodoc</F> file like this?
+## First Section
+### First Subsection
 @BeginExampleSession
 gap> S5 := SymmetricGroup(5);
 Sym( [ 1 .. 5 ] )


### PR DESCRIPTION
Allow #, ##, ### headings in .autodoc and #! comments as aliases
for @Chapter/@Section/@Subsection. Add parser coverage in
misc tests and update autoplain worksheet expected output.

Resolves #213

Co-authored-by: Codex <codex@openai.com>
