### PR TITLE
parser: fix markdown headings in .autodoc

### DIFF
--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -87,12 +87,28 @@ end );
 ##
 InstallGlobalFunction( Scan_for_AutoDoc_Part,
   function( line, plain_text_mode )
-    local position;
+    local position, trimmed, heading;
     position := AUTODOC_PositionPrefixShebang( line );
     if position = fail and plain_text_mode = false then
         return [ false, line ];
     fi;
-    if plain_text_mode <> true then
+    if plain_text_mode = true then
+        trimmed := StripBeginEnd( line, " \t\r\n" );
+        if trimmed = "" then
+            return [ "STRING", line ];
+        fi;
+        if trimmed[ 1 ] = '#' then
+            heading := AUTODOC_SplitMarkdownHeading( trimmed );
+            if heading = fail then
+                return [ "STRING", line ];
+            fi;
+            return heading;
+        fi;
+        if trimmed[ 1 ] <> '@' then
+            return [ "STRING", line ];
+        fi;
+        line := trimmed;
+    else
         line := StripBeginEnd( line{[ position + 2 .. Length( line ) ]}, " " );
     fi;
     return AUTODOC_SplitCommandAndArgument( line );

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -88,9 +88,13 @@ fail
 # Scan_for_AutoDoc_Part: robust command splitting
 #
 gap> Scan_for_AutoDoc_Part( "plain text @Section   Intro", true );
-[ "@Section", "Intro" ]
+[ "STRING", "plain text @Section   Intro" ]
 gap> Scan_for_AutoDoc_Part( "   @Chapter   My Chapter", true );
 [ "@Chapter", "My Chapter" ]
+gap> Scan_for_AutoDoc_Part( "   @Section   My Section", true );
+[ "@Section", "My Section" ]
+gap> Scan_for_AutoDoc_Part( "   @Subsection   My Subsection", true );
+[ "@Subsection", "My Subsection" ]
 gap> Scan_for_AutoDoc_Part( "   @NoArg", true );
 [ "@NoArg", "" ]
 gap> Scan_for_AutoDoc_Part( "no command here", true );


### PR DESCRIPTION
Fix plain-text mode so markdown-style headings are handled before
treating the line as plain text. This restores heading aliases in
.autodoc files.

A line like plain text @Section Intro is now treated as plain
text, not as a command. After all, the documentation states:
> Any [...] line that does not start with an AutoDoc command is
> treated as regular documentation text [...]

Co-authored-by: Codex <codex@openai.com>
