### PR TITLE
Enhance Markdown backtick support to handle GAP keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ This file describes changes in the AutoDoc package.
   - Add fenced code blocks using triple backticks or tildes in
     Markdown-like text; `@listing`, `@example`, and `@log` info strings
     select the corresponding GAPDoc element
+  - In Markdown-like inline backtick code spans, emit
+    `<Keyword>...</Keyword>` for GAP keywords (as returned by
+    `ALL_KEYWORDS()`), otherwise as before `<Code>...</Code>`
   - Allow XML-style comments in `.autodoc` files
   - Greatly improve the package manual.
   - Fix an unexpected and confusing error when mixing explicit

--- a/gap/Markdown.gi
+++ b/gap/Markdown.gi
@@ -23,7 +23,8 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
           commands, position_of_command, insert, beginning_whitespaces, temp, string_list_temp, skipped,
           already_inserted_paragraph, in_list, in_item, converted_string_list,
           fence_char, fence_length, trimmed_line, code_block, info_string,
-          fence_element;
+          fence_element, keyword_set, opening_pos, closing_pos, inline_content,
+          tag_name;
 
     converted_string_list := [ ];
     i := 1;
@@ -210,9 +211,48 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
     ## Find commands
     command_list_with_translation := [ [ "$$", "Display" ],
                                        [ "$", "Math" ],
-                                       [ "`", "Code" ],
                                        [ "**", "Emph" ],
                                        [ "__", "Emph" ] ];
+    keyword_set := Set( ALL_KEYWORDS() );
+
+    skipped := false;
+    for i in [ 1 .. Length( string_list ) ] do
+        if PositionSublist( string_list[ i ], "<![CDATA[" ) <> fail then
+            skipped := true;
+        fi;
+        if PositionSublist( string_list[ i ], "]]>" ) <> fail then
+            skipped := false;
+            continue;
+        fi;
+        if skipped = true then
+            continue;
+        fi;
+
+        while PositionSublist( string_list[ i ], "`" ) <> fail do
+            opening_pos := PositionSublist( string_list[ i ], "`" );
+            closing_pos := PositionSublist( string_list[ i ], "`", opening_pos + 1 );
+            if closing_pos = fail then
+                Error( "did you forget some `" );
+            fi;
+
+            if opening_pos + 1 <= closing_pos - 1 then
+                inline_content := string_list[ i ]{ [ opening_pos + 1 .. closing_pos - 1 ] };
+            else
+                inline_content := "";
+            fi;
+            if inline_content in keyword_set then
+                tag_name := "Keyword";
+            else
+                tag_name := "Code";
+            fi;
+            string_list[ i ] := Concatenation(
+                string_list[ i ]{ [ 1 .. opening_pos - 1 ] },
+                "<", tag_name, ">", inline_content, "</", tag_name, ">",
+                string_list[ i ]{ [ closing_pos + 1 .. Length( string_list[ i ] ) ] }
+            );
+        od;
+    od;
+
     ## special handling for \$
     for i in [ 1 .. Length( string_list ) ] do
         string_list[ i ] := ReplacedString( string_list[ i ], "\\$", "&#36;" );

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -29,6 +29,7 @@ gap> Size(A5);
 ]]></Example>
 
 
+Also, markdown-like inline <Keyword>true</Keyword> should become a keyword tag.
 And we wrap up with some dummy text
 </Subsection>
 

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -19,4 +19,5 @@ Alt( [ 1 .. 5 ] )
 gap> Size(A5);
 60
 @EndExampleSession
+Also, markdown-like inline `true` should become a keyword tag.
 And we wrap up with some dummy text

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -101,6 +101,9 @@ This is also <Emph>emphasized</Emph> text in a list item.
 <Item>
 This is <Code>inline code</Code> in a list item.
 </Item>
+<Item>
+This is <Keyword>true</Keyword> in a list item.
+</Item>
 </List>
 <P/>
  All of this can <Emph>also</Emph> be <Emph>used</Emph> outside of a <Code>list</Code>.

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -55,6 +55,7 @@ DeclareCategoryCollections("MyThingsCollection");
 #! * This is __emphasized__ text in a list item.
 #! * This is also **emphasized** text in a list item.
 #! * This is `inline code` in a list item.
+#! * This is `true` in a list item.
 #!
 #! All of this can **also** be __used__ outside of a `list`.
 


### PR DESCRIPTION
Partial progress towards resolving issue #207.

Co-authored-by: Codex <codex@openai.com>
