### PR TITLE
Fix LaTeX warning from chapter reference

### DIFF
--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -45,7 +45,7 @@
 #! </Enum>
 #! These tasks can be enabled independently, so you can use as much or as
 #! little of &AutoDoc; as your package currently needs.
-#! For more information and some examples, please refer to Chapter <Ref Label='Chapter_Tutorials'/>.
+#! For more information and some examples, please refer to Chapter <Ref Chap='Chapter_Tutorials'/>.
 #! <P/>
 #! The parameters have the following meanings:
 #! <List>

--- a/tst/manual.expected/_Chapter_Reference.xml
+++ b/tst/manual.expected/_Chapter_Reference.xml
@@ -79,7 +79,7 @@
  </Enum>
  These tasks can be enabled independently, so you can use as much or as
  little of &AutoDoc; as your package currently needs.
- For more information and some examples, please refer to Chapter <Ref Label='Chapter_Tutorials'/>.
+ For more information and some examples, please refer to Chapter <Ref Chap='Chapter_Tutorials'/>.
  <P/>
  The parameters have the following meanings:
  <List>


### PR DESCRIPTION
Use `<Ref Chap='Chapter_Tutorials'/>` in Magic.gd instead of `<Ref Label='Chapter_Tutorials'/>` to avoid invalid LaTeX reference expansion with escaped underscores.

Co-authored-by: Codex <codex@openai.com>

See also https://github.com/gap-actions/build-pkg-docs/pull/43 which will hopefully ensure this kind of problem is noticed by CI and thus can be fixed before changes are merged.