### PR TITLE
Add @Index command for index entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ This file describes changes in the AutoDoc package.
   - Add fenced code blocks using triple backticks or tildes in
     Markdown-like text; `@listing`, `@example`, and `@log` info strings
     select the corresponding GAPDoc element
+  - Add `@Index` command for generating index entries
   - In Markdown-like inline backtick code spans, emit
     `<Keyword>...</Keyword>` for GAP keywords (as returned by
     `ALL_KEYWORDS()`), otherwise as before `<Code>...</Code>`

--- a/doc/Comments.autodoc
+++ b/doc/Comments.autodoc
@@ -52,7 +52,7 @@ before the declaration. Currently, the following commands are provided:
 @Subsection <C>@Description <A>descr</A></C>
 @SubsectionLabel @Description
 
-<Index Key="@Description"><C>@Description <A>descr</A></C></Index>
+@Index "@Description" <C>@Description <A>descr</A></C>
 Adds the text in the following lines of the &AutoDoc; to the description
 of the declaration in the manual. Lines are until the next &AutoDoc; command
 or until the declaration is reached.
@@ -60,7 +60,7 @@ or until the declaration is reached.
 @Subsection <C>@Returns <A>ret_val</A></C>
 @SubsectionLabel @Returns
 
-<Index Key="@Returns"><C>@Returns <A>ret_val</A></C></Index>
+@Index "@Returns" <C>@Returns <A>ret_val</A></C>
 The string <A>ret_val</A> is added to the documentation, with the text <Q>Returns: </Q>
 put in front of it. This should usually give a brief hint about the type or meaning
 of the value returned by the documented function.
@@ -68,7 +68,7 @@ of the value returned by the documented function.
 @Subsection <C>@Arguments <A>args</A></C>
 @SubsectionLabel @Arguments
 
-<Index Key="@Arguments"><C>@Arguments <A>args</A></C></Index>
+@Index "@Arguments" <C>@Arguments <A>args</A></C>
 The string <A>args</A> contains a description of the arguments the
 function expects, including optional parts, which are denoted by square
 brackets. The argument names can be separated by whitespace, commas or
@@ -79,14 +79,14 @@ and one or more assignments, like <Q>n[, r]: tries := 100</Q>.
 @Subsection <C>@Group <A>grpname</A></C>
 @SubsectionLabel @Group
 
-<Index Key="@Group"><C>@Group <A>grpname</A></C></Index>
+@Index "@Group" <C>@Group <A>grpname</A></C>
 Adds the following method to a group with the given name.
 See section <Ref Sect="Section_Groups"/> for more information about groups.
 
 @Subsection <C>@Label <A>label</A></C>
 @SubsectionLabel @Label
 
-<Index Key="@Label"><C>@Label <A>label</A></C></Index>
+@Index "@Label" <C>@Label <A>label</A></C>
 Adds label to the function as label.
 
 If this is not specified, then for declarations that involve a list of input filters
@@ -128,7 +128,7 @@ leads to this:
 @Subsection <C>@ChapterInfo <A>chapter</A>, <A>section</A></C>
 @SubsectionLabel @ChapterInfo
 
-<Index Key="@ChapterInfo"><C>@ChapterInfo</C></Index>
+@Index "@ChapterInfo" `@ChapterInfo`
 Adds the entry to the given chapter and section. Here,
 <A>chapter</A> and <A>section</A> are the respective
 titles.
@@ -158,9 +158,9 @@ text in your documentation, examples, mathematical chapters, etc.
 @Subsection <C>@Chapter <A>name</A></C>
 @SubsectionLabel @Chapter
 
-<Index Key="@Chapter"><C>@Chapter</C></Index>
-<Index Key="@ChapterLabel"><C>@ChapterLabel</C></Index>
-<Index Key="@ChapterTitle"><C>@ChapterTitle</C></Index>
+@Index "@Chapter" `@Chapter`
+@Index "@ChapterLabel" `@ChapterLabel`
+@Index "@ChapterTitle" `@ChapterTitle`
 Sets the active chapter, all subsequent functions which do not have an explicit chapter
 declared in their &AutoDoc; comment via <C>@ChapterInfo</C> will be added to this chapter.
 Also all text comments, i.e. lines that begin with #! without a command, and which do not
@@ -197,9 +197,9 @@ for setting the same chapter as active chapter again.
 @Subsection <C>@Section <A>name</A></C>
 @SubsectionLabel @Section
 
-<Index Key="@Section"><C>@Section</C></Index>
-<Index Key="@SectionLabel"><C>@SectionLabel</C></Index>
-<Index Key="@SectionTitle"><C>@SectionTitle</C></Index>
+@Index "@Section" `@Section`
+@Index "@SectionLabel" `@SectionLabel`
+@Index "@SectionTitle" `@SectionTitle`
 Sets an active section like <C>@Chapter</C> sets an active chapter.
 The section automatically ends with the next <C>@Section</C> or <C>@Chapter</C> command.
 
@@ -218,9 +218,9 @@ can be used to set a heading for the section that is different from <A>name</A>.
 @Subsection <C>@Subsection <A>name</A></C>
 @SubsectionLabel @Subsection
 
-<Index Key="@Subsection"><C>@Subsection</C></Index>
-<Index Key="@SubsectionLabel"><C>@SubsectionLabel</C></Index>
-<Index Key="@SubsectionTitle"><C>@SubsectionTitle</C></Index>
+@Index "@Subsection" `@Subsection`
+@Index "@SubsectionLabel" `@SubsectionLabel`
+@Index "@SubsectionTitle" `@SubsectionTitle`
 Sets an active subsection like <C>@Section</C> sets an active section.
 The subsection automatically ends with the next <C>@Subsection</C>,
 <C>@Section</C> or <C>@Chapter</C> command. It also ends with the
@@ -242,7 +242,7 @@ can be used to set a heading for the subsection that is different from <A>name</
 @Subsection <C>@BeginGroup <A>[grpname]</A></C>
 @SubsectionLabel @BeginGroup
 
-<Index Key="@BeginGroup"><C>@BeginGroup</C></Index>
+@Index "@BeginGroup" `@BeginGroup`
 Starts a group. All following documented declarations without an
 explicit <C>@Group</C> command are grouped together in the same group
 with the given name. If no name is given, then a new nameless group is
@@ -255,7 +255,7 @@ See section <Ref Sect="Section_Groups"/> for more information about groups.
 @Subsection <C>@EndGroup</C>
 @SubsectionLabel @EndGroup
 
-<Index Key="@EndGroup"><C>@EndGroup</C></Index>
+@Index "@EndGroup" `@EndGroup`
 Ends the current group.
 
 ```@listing
@@ -276,7 +276,7 @@ DeclareOperation( "GroupedOperation",
 @Subsection @GroupTitle <A>title</A>
 @SubsectionLabel @GroupTitle
 
-<Index Key="@GroupTitle"><C>@GroupTitle</C></Index>
+@Index "@GroupTitle" `@GroupTitle`
 Sets the subsection heading for the current group to <A>title</A>. In the
 absence of any <C>@GroupTitle</C> command, the heading will be the name of the
 first entry in the group. See <Ref Sect="Section_Groups"/> for more information.
@@ -284,7 +284,7 @@ first entry in the group. See <Ref Sect="Section_Groups"/> for more information.
 @Subsection <C>@Level <A>lvl</A></C>
 @SubsectionLabel @Level
 
-<Index Key="@Level"><C>@Level</C></Index>
+@Index "@Level" `@Level`
 Sets the current level of the documentation. All items created after this,
 chapters, sections, and items, are given the level <A>lvl</A>,
 until the <C>@ResetLevel</C> command resets the level to 0 or another level
@@ -295,14 +295,14 @@ See section <Ref Sect="Section_Level"/> for more information about levels.
 @Subsection <C>@ResetLevel</C>
 @SubsectionLabel @ResetLevel
 
-<Index Key="@ResetLevel"><C>@ResetLevel</C></Index>
+@Index "@ResetLevel" `@ResetLevel`
 Resets the current level to 0.
 
 @Subsection <C>@BeginExample</C> and <C>@EndExample</C>
 @SubsectionLabel @BeginExample
 
-<Index Key="@BeginExample"><C>@BeginExample</C></Index>
-<Index Key="@EndExample"><C>@EndExample</C></Index>
+@Index "@BeginExample" `@BeginExample`
+@Index "@EndExample" `@EndExample`
 <C>@BeginExample</C> marks the start of an example to be put into the manual.
 It differs from &GAPDoc;'s <C>&lt;Example></C> (see <Ref Subsect="Log" BookName="gapdoc"/>),
 in that it expects actual code (not in a comment) interspersed with comments,
@@ -336,8 +336,8 @@ Section <Ref Sect="Subsection_Tut:IntegrateExisting:EverythingThere"/>).
 @Subsection <C>@BeginExampleSession</C> and <C>@EndExampleSession</C>
 @SubsectionLabel @BeginExampleSession
 
-<Index Key="@BeginExampleSession"><C>@BeginExampleSession</C></Index>
-<Index Key="@EndExampleSession"><C>@EndExampleSession</C></Index>
+@Index "@BeginExampleSession" `@BeginExampleSession`
+@Index "@EndExampleSession" `@EndExampleSession`
 <C>@BeginExampleSession</C> marks the start of an example to be put into the manual,
 while <C>@EndExampleSession</C> ends the example block.
 It is the direct analog of &GAPDoc;'s <C>&lt;Example></C> (see <Ref Subsect="Log" BookName="gapdoc"/>).
@@ -372,8 +372,8 @@ The &AutoDoc; command <C>@ExampleSession</C> is an alias of <C>@BeginExampleSess
 @Subsection <C>@BeginLog</C> and <C>@EndLog</C>
 @SubsectionLabel @BeginLog
 
-<Index Key="@BeginLog"><C>@BeginLog</C></Index>
-<Index Key="@EndLog"><C>@EndLog</C></Index>
+@Index "@BeginLog" `@BeginLog`
+@Index "@EndLog" `@EndLog`
 Works just like the <C>@BeginExample</C> command, but the example
 will not be tested. See the &GAPDoc; manual for more information.
 The &AutoDoc; command <C>@Log</C> is an alias of <C>@BeginLog</C>.
@@ -381,8 +381,8 @@ The &AutoDoc; command <C>@Log</C> is an alias of <C>@BeginLog</C>.
 @Subsection <C>@BeginLogSession</C> and <C>@EndLogSession</C>
 @SubsectionLabel @BeginLogSession
 
-<Index Key="@BeginLogSession"><C>@BeginLogSession</C></Index>
-<Index Key="@EndLogSession"><C>@EndLogSession</C></Index>
+@Index "@BeginLogSession" `@BeginLogSession`
+@Index "@EndLogSession" `@EndLogSession`
 Works just like the <C>@BeginExampleSession</C> command, but the example
 will not be tested if manual examples are run. It is the direct analog of
 &GAPDoc;'s <C>&lt;Log></C> (see <Ref Subsect="Log" BookName="gapdoc"/>).
@@ -391,7 +391,7 @@ The &AutoDoc; command <C>@LogSession</C> is an alias of <C>@BeginLogSession</C>.
 @Subsection <C>@DoNotReadRestOfFile</C>
 @SubsectionLabel @DoNotReadRestOfFile
 
-<Index Key="@DoNotReadRestOfFile"><C>@DoNotReadRestOfFile</C></Index>
+@Index "@DoNotReadRestOfFile" `@DoNotReadRestOfFile`
 Prevents the rest of the file from being read by the parser. Useful for
 unfinished or temporary files.
 
@@ -406,9 +406,9 @@ unfinished or temporary files.
 @Subsection <C>@BeginChunk <A>name</A></C>, <C>@EndChunk</C>, and <C>@InsertChunk <A>name</A></C>
 @SubsectionLabel @BeginChunk
 
-<Index Key="@BeginChunk"><C>@BeginChunk <A>name</A></C></Index>
-<Index Key="@EndChunk"><C>@EndChunk</C></Index>
-<Index Key="@EndChunk"><C>@InsertChunk <A>name</A></C></Index>
+@Index "@BeginChunk" <C>@BeginChunk <A>name</A></C>
+@Index "@EndChunk" `@EndChunk`
+@Index "@EndChunk" <C>@InsertChunk <A>name</A></C>
 Text inside a <C>@BeginChunk</C> / <C>@EndChunk</C> part will not be inserted into
 the final documentation directly. Instead, the text is stored in an internal buffer.
 
@@ -447,9 +447,9 @@ And then later, insert the example in a different file, like this:
 @Subsection <C>@BeginCode <A>name</A></C>, @EndCode, and <C>@InsertCode <A>name</A></C>
 @SubsectionLabel @BeginCode
 
-<Index Key="@BeginCode"><C>@BeginCode <A>name</A></C></Index>
-<Index Key="@EndCode"><C>@EndCode</C></Index>
-<Index Key="@InsertCode"><C>@InsertCode <A>name</A></C></Index>
+@Index "@BeginCode" <C>@BeginCode <A>name</A></C>
+@Index "@EndCode" `@EndCode`
+@Index "@InsertCode" <C>@InsertCode <A>name</A></C>
 Inserts the text between <C>@BeginCode</C> and <C>@EndCode</C> verbatim at the point where
 <C>@InsertCode</C> is called. This is useful to insert code excerpts
 directly into the manual.
@@ -465,9 +465,9 @@ i := i + 1;
 @Subsection <C>@LatexOnly <A>text</A></C>, <C>@BeginLatexOnly</C>, and <C>@EndLatexOnly</C>
 @SubsectionLabel @LatexOnly
 
-<Index Key="@LatexOnly"><C>@LatexOnly <A>text</A></C></Index>
-<Index Key="@BeginLatexOnly"><C>@BeginLatexOnly</C></Index>
-<Index Key="@EndLatexOnly"><C>@EndLatexOnly</C></Index>
+@Index "@LatexOnly" <C>@LatexOnly <A>text</A></C>
+@Index "@BeginLatexOnly" `@BeginLatexOnly`
+@Index "@EndLatexOnly" `@EndLatexOnly`
 Code inserted between <C>@BeginLatexOnly</C> and <C>@EndLatexOnly</C> or after <C>@LatexOnly</C> is only inserted
 in the PDF version of the manual or worksheet. It can hold arbitrary &LaTeX;-commands.
 ```@listing
@@ -481,9 +481,9 @@ in the PDF version of the manual or worksheet. It can hold arbitrary &LaTeX;-com
 @Subsection <C>@NotLatex <A>text</A></C>, <C>@BeginNotLatex</C>, and <C>@EndNotLatex</C>
 @SubsectionLabel @NotLatex
 
-<Index Key="@NotLatex"><C>@NotLatex <A>text</A></C></Index>
-<Index Key="@BeginNotLatex"><C>@BeginNotLatex</C></Index>
-<Index Key="@EndNotLatex"><C>@EndNotLatex</C></Index>
+@Index "@NotLatex" <C>@NotLatex <A>text</A></C>
+@Index "@BeginNotLatex" `@BeginNotLatex`
+@Index "@EndNotLatex" `@EndNotLatex`
 Code inserted between <C>@BeginNotLatex</C> and <C>@EndNotLatex</C> or after <C>@NotLatex</C> is inserted
 in the HTML and text versions of the manual or worksheet, but not in the PDF version.
 ```@listing
@@ -493,6 +493,19 @@ in the HTML and text versions of the manual or worksheet, but not in the PDF ver
 
 #! @NotLatex For further information see the PDF version of this manual.
 ```
+
+@Subsection <C>@Index <A>key</A> [<A>entry text</A>]</C>
+@SubsectionLabel @Index
+
+@Index "@Index" <C>@Index <A>key</A> [<A>entry text</A>]</C>
+Adds an index entry to the current documentation text.
+The command <C>@Index key entry text</C> generates
+<C>&lt;Index Key="key"&gt;entry text&lt;/Index&gt;</C>.
+If no entry text is provided, then the entry text is empty.
+To use keys containing spaces, wrap the key in double quotes, e.g.
+<C>@Index "my key" entry text</C>.
+The entry text is processed like normal documentation text, so markdown-like
+inline code such as `true` is supported.
 
 @Section Title page commands
 @SectionLabel TitlepageCommands

--- a/doc/Tutorials.autodoc
+++ b/doc/Tutorials.autodoc
@@ -76,7 +76,7 @@ You will probably want to re-run the  <Ref Func="AutoDoc"/> command
 frequently, e.g. whenever you modified your documentation or your
 <F>PackageInfo.g</F>. To make this more convenient and reproducible, we
 recommend putting its invocation into a file <F>makedoc.g</F> in your package
-<Index Key="makedoc.g"><F>makedoc.g</F></Index>
+@Index "makedoc.g" <F>makedoc.g</F>
 directory, with content based on the following example:
 ```@listing
 LoadPackage( "AutoDoc" );
@@ -326,13 +326,13 @@ Edit <File>PackageName/makedoc.g</File> as follows.
   In the <Code>AutoDoc</Code> record delete <Code>autodoc := true;</Code>. 
   </Item>
   <Item> 
-  <Index Key="Scaffold record in makedoc.g"></Index> 
+  @Index "Scaffold record in makedoc.g"
   In the <Code>scaffold</Code> record change the <Code>includes</Code> list 
   to be the list of your <Code>.xml</Code> files that are contained in  
   <File>manual.xml</File>. 
   </Item> 
   <Item>
-  <Index Key="Bibliography field in makedoc.g"></Index> 
+  @Index "Bibliography field in makedoc.g"
   If you do not have a bibliography you may delete the 
   <Code>bib := "bib.xml",</Code> field in the scaffold. 
   Otherwise, edit the file name if you have a different file. 
@@ -341,7 +341,7 @@ Edit <File>PackageName/makedoc.g</File> as follows.
   you should rename this file <File>PackageName.bib</File>. 
   </Item>
   <Item> 
-  <Index Key="LaTeXOptions record in makedoc.g"></Index>
+  @Index "LaTeXOptions record in makedoc.g"
   In the <Code>LaTeXOptions</Code> record,
   which is in the <Code>gapdoc</Code> record, enter any
   &LaTeX; <Code>newcommands</Code> previously in <File>manual.xml</File>. 
@@ -368,9 +368,9 @@ Now edit <File>PackageName/PackageInfo.g</File> as follows.
   to the end of your file (just before the final <Code>"));"</Code>. 
   </Item>
   <Item> 
-  <Index Key="Copyright field in PackageInfo.g"></Index> 
-  <Index Key="Abstract field in PackageInfo.g"></Index> 
-  <Index Key="Acknowledgements field in PackageInfo.g"></Index> 
+  @Index "Copyright field in PackageInfo.g"
+  @Index "Abstract field in PackageInfo.g"
+  @Index "Acknowledgements field in PackageInfo.g"
   Replace the <Code>Copyright</Code>, <Code>Abstract</Code> and 
   <Code>Acknowledgements</Code> fields of the <Code>TitlePage</Code> 
   record with the corresponding material from your <File>manual.xml</File>. 
@@ -380,7 +380,7 @@ Now edit <File>PackageName/PackageInfo.g</File> as follows.
 <!--  consult the file <File>gap/Magic.gd</File>. -->
   </Item>
   <Item> 
-  <Index Key="Entities record in makedoc.g"></Index> 
+  @Index "Entities record in makedoc.g"
   In the <Code>entities</Code> record enter any entities 
   previously stored in your <File>manual.xml</File>. 
   (Again, if you have none, you may safely delete this record.) 

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -836,6 +836,84 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         @Level := function()
             current_item!.level := Int( current_command[ 2 ] );
         end,
+        @Index := function()
+            local argument, split_pos, key, entry,
+                  escaped_quote_pos, key_string, key_escaped;
+            if not IsBound( current_item ) then
+                ErrorWithPos( "found @Index with no active documentation item" );
+            fi;
+            argument := StripBeginEnd( current_command[ 2 ], " \t\r\n" );
+            if argument = "" then
+                ErrorWithPos( "found @Index without arguments" );
+            fi;
+            entry := "";
+            if argument[ 1 ] = '"' then
+                escaped_quote_pos := 2;
+                while escaped_quote_pos <= Length( argument ) and
+                      argument[ escaped_quote_pos ] <> '"' do
+                    escaped_quote_pos := escaped_quote_pos + 1;
+                od;
+                if escaped_quote_pos > Length( argument ) then
+                    ErrorWithPos( "found @Index with unterminated quoted key" );
+                fi;
+                key := argument{ [ 2 .. escaped_quote_pos - 1 ] };
+                split_pos := escaped_quote_pos + 1;
+                while split_pos <= Length( argument ) and argument[ split_pos ] in " \t\r\n" do
+                    split_pos := split_pos + 1;
+                od;
+                if split_pos <= Length( argument ) then
+                    entry := argument{ [ split_pos .. Length( argument ) ] };
+                fi;
+            else
+                split_pos := PositionProperty( argument, c -> c in " \t\r\n" );
+                if split_pos = fail then
+                    key := argument;
+                else
+                    key := argument{ [ 1 .. split_pos - 1 ] };
+                    while split_pos <= Length( argument ) and argument[ split_pos ] in " \t\r\n" do
+                        split_pos := split_pos + 1;
+                    od;
+                    if split_pos <= Length( argument ) then
+                        entry := argument{ [ split_pos .. Length( argument ) ] };
+                    fi;
+                fi;
+            fi;
+
+            key_string := key;
+            key_escaped := "";
+            while key_string <> "" do
+                split_pos := PositionProperty( key_string, c -> c in "&\"<>" );
+                if split_pos = fail then
+                    key_escaped := Concatenation( key_escaped, key_string );
+                    key_string := "";
+                elif split_pos > 1 then
+                    key_escaped := Concatenation( key_escaped, key_string{ [ 1 .. split_pos - 1 ] } );
+                    key_string := key_string{ [ split_pos .. Length( key_string ) ] };
+                fi;
+                if key_string = "" then
+                    break;
+                fi;
+                if key_string[ 1 ] = '&' then
+                    key_escaped := Concatenation( key_escaped, "&amp;" );
+                elif key_string[ 1 ] = '"' then
+                    key_escaped := Concatenation( key_escaped, "&quot;" );
+                elif key_string[ 1 ] = '<' then
+                    key_escaped := Concatenation( key_escaped, "&lt;" );
+                else
+                    key_escaped := Concatenation( key_escaped, "&gt;" );
+                fi;
+                if Length( key_string ) > 1 then
+                    key_string := key_string{ [ 2 .. Length( key_string ) ] };
+                else
+                    key_string := "";
+                fi;
+            od;
+
+            if key_escaped = "" then
+                ErrorWithPos( "found @Index with empty key" );
+            fi;
+            Add( current_item, Concatenation( "<Index Key=\"", key_escaped, "\">", entry, "</Index>" ) );
+        end,
 
         @InsertChunk := function()
             local label_name;

--- a/tst/manual.expected/_Chapter_Comments.xml
+++ b/tst/manual.expected/_Chapter_Comments.xml
@@ -152,7 +152,7 @@ leads to this:
 <Heading><C>@ChapterInfo <A>chapter</A>, <A>section</A></C></Heading>
 
 <P/>
-<Index Key="@ChapterInfo"><C>@ChapterInfo</C></Index>
+<Index Key="@ChapterInfo"><Code>@ChapterInfo</Code></Index>
 Adds the entry to the given chapter and section. Here,
 <A>chapter</A> and <A>section</A> are the respective
 titles.
@@ -191,9 +191,9 @@ text in your documentation, examples, mathematical chapters, etc.
 <Heading><C>@Chapter <A>name</A></C></Heading>
 
 <P/>
-<Index Key="@Chapter"><C>@Chapter</C></Index>
-<Index Key="@ChapterLabel"><C>@ChapterLabel</C></Index>
-<Index Key="@ChapterTitle"><C>@ChapterTitle</C></Index>
+<Index Key="@Chapter"><Code>@Chapter</Code></Index>
+<Index Key="@ChapterLabel"><Code>@ChapterLabel</Code></Index>
+<Index Key="@ChapterTitle"><Code>@ChapterTitle</Code></Index>
 Sets the active chapter, all subsequent functions which do not have an explicit chapter
 declared in their &AutoDoc; comment via <C>@ChapterInfo</C> will be added to this chapter.
 Also all text comments, i.e. lines that begin with #! without a command, and which do not
@@ -234,9 +234,9 @@ for setting the same chapter as active chapter again.
 <Heading><C>@Section <A>name</A></C></Heading>
 
 <P/>
-<Index Key="@Section"><C>@Section</C></Index>
-<Index Key="@SectionLabel"><C>@SectionLabel</C></Index>
-<Index Key="@SectionTitle"><C>@SectionTitle</C></Index>
+<Index Key="@Section"><Code>@Section</Code></Index>
+<Index Key="@SectionLabel"><Code>@SectionLabel</Code></Index>
+<Index Key="@SectionTitle"><Code>@SectionTitle</Code></Index>
 Sets an active section like <C>@Chapter</C> sets an active chapter.
 The section automatically ends with the next <C>@Section</C> or <C>@Chapter</C> command.
 <P/>
@@ -259,9 +259,9 @@ can be used to set a heading for the section that is different from <A>name</A>.
 <Heading><C>@Subsection <A>name</A></C></Heading>
 
 <P/>
-<Index Key="@Subsection"><C>@Subsection</C></Index>
-<Index Key="@SubsectionLabel"><C>@SubsectionLabel</C></Index>
-<Index Key="@SubsectionTitle"><C>@SubsectionTitle</C></Index>
+<Index Key="@Subsection"><Code>@Subsection</Code></Index>
+<Index Key="@SubsectionLabel"><Code>@SubsectionLabel</Code></Index>
+<Index Key="@SubsectionTitle"><Code>@SubsectionTitle</Code></Index>
 Sets an active subsection like <C>@Section</C> sets an active section.
 The subsection automatically ends with the next <C>@Subsection</C>,
 <C>@Section</C> or <C>@Chapter</C> command. It also ends with the
@@ -287,7 +287,7 @@ can be used to set a heading for the subsection that is different from <A>name</
 <Heading><C>@BeginGroup <A>[grpname]</A></C></Heading>
 
 <P/>
-<Index Key="@BeginGroup"><C>@BeginGroup</C></Index>
+<Index Key="@BeginGroup"><Code>@BeginGroup</Code></Index>
 Starts a group. All following documented declarations without an
 explicit <C>@Group</C> command are grouped together in the same group
 with the given name. If no name is given, then a new nameless group is
@@ -304,7 +304,7 @@ See section <Ref Sect="Section_Groups"/> for more information about groups.
 <Heading><C>@EndGroup</C></Heading>
 
 <P/>
-<Index Key="@EndGroup"><C>@EndGroup</C></Index>
+<Index Key="@EndGroup"><Code>@EndGroup</Code></Index>
 Ends the current group.
 <P/>
 <Listing><![CDATA[
@@ -329,7 +329,7 @@ DeclareOperation( "GroupedOperation",
 <Heading>@GroupTitle <A>title</A></Heading>
 
 <P/>
-<Index Key="@GroupTitle"><C>@GroupTitle</C></Index>
+<Index Key="@GroupTitle"><Code>@GroupTitle</Code></Index>
 Sets the subsection heading for the current group to <A>title</A>. In the
 absence of any <C>@GroupTitle</C> command, the heading will be the name of the
 first entry in the group. See <Ref Sect="Section_Groups"/> for more information.
@@ -341,7 +341,7 @@ first entry in the group. See <Ref Sect="Section_Groups"/> for more information.
 <Heading><C>@Level <A>lvl</A></C></Heading>
 
 <P/>
-<Index Key="@Level"><C>@Level</C></Index>
+<Index Key="@Level"><Code>@Level</Code></Index>
 Sets the current level of the documentation. All items created after this,
 chapters, sections, and items, are given the level <A>lvl</A>,
 until the <C>@ResetLevel</C> command resets the level to 0 or another level
@@ -356,7 +356,7 @@ See section <Ref Sect="Section_Level"/> for more information about levels.
 <Heading><C>@ResetLevel</C></Heading>
 
 <P/>
-<Index Key="@ResetLevel"><C>@ResetLevel</C></Index>
+<Index Key="@ResetLevel"><Code>@ResetLevel</Code></Index>
 Resets the current level to 0.
 <P/>
 </Subsection>
@@ -366,8 +366,8 @@ Resets the current level to 0.
 <Heading><C>@BeginExample</C> and <C>@EndExample</C></Heading>
 
 <P/>
-<Index Key="@BeginExample"><C>@BeginExample</C></Index>
-<Index Key="@EndExample"><C>@EndExample</C></Index>
+<Index Key="@BeginExample"><Code>@BeginExample</Code></Index>
+<Index Key="@EndExample"><Code>@EndExample</Code></Index>
 <C>@BeginExample</C> marks the start of an example to be put into the manual.
 It differs from &GAPDoc;'s <C>&lt;Example></C> (see <Ref Subsect="Log" BookName="gapdoc"/>),
 in that it expects actual code (not in a comment) interspersed with comments,
@@ -405,8 +405,8 @@ Section <Ref Sect="Subsection_Tut:IntegrateExisting:EverythingThere"/>).
 <Heading><C>@BeginExampleSession</C> and <C>@EndExampleSession</C></Heading>
 
 <P/>
-<Index Key="@BeginExampleSession"><C>@BeginExampleSession</C></Index>
-<Index Key="@EndExampleSession"><C>@EndExampleSession</C></Index>
+<Index Key="@BeginExampleSession"><Code>@BeginExampleSession</Code></Index>
+<Index Key="@EndExampleSession"><Code>@EndExampleSession</Code></Index>
 <C>@BeginExampleSession</C> marks the start of an example to be put into the manual,
 while <C>@EndExampleSession</C> ends the example block.
 It is the direct analog of &GAPDoc;'s <C>&lt;Example></C> (see <Ref Subsect="Log" BookName="gapdoc"/>).
@@ -445,8 +445,8 @@ The &AutoDoc; command <C>@ExampleSession</C> is an alias of <C>@BeginExampleSess
 <Heading><C>@BeginLog</C> and <C>@EndLog</C></Heading>
 
 <P/>
-<Index Key="@BeginLog"><C>@BeginLog</C></Index>
-<Index Key="@EndLog"><C>@EndLog</C></Index>
+<Index Key="@BeginLog"><Code>@BeginLog</Code></Index>
+<Index Key="@EndLog"><Code>@EndLog</Code></Index>
 Works just like the <C>@BeginExample</C> command, but the example
 will not be tested. See the &GAPDoc; manual for more information.
 The &AutoDoc; command <C>@Log</C> is an alias of <C>@BeginLog</C>.
@@ -458,8 +458,8 @@ The &AutoDoc; command <C>@Log</C> is an alias of <C>@BeginLog</C>.
 <Heading><C>@BeginLogSession</C> and <C>@EndLogSession</C></Heading>
 
 <P/>
-<Index Key="@BeginLogSession"><C>@BeginLogSession</C></Index>
-<Index Key="@EndLogSession"><C>@EndLogSession</C></Index>
+<Index Key="@BeginLogSession"><Code>@BeginLogSession</Code></Index>
+<Index Key="@EndLogSession"><Code>@EndLogSession</Code></Index>
 Works just like the <C>@BeginExampleSession</C> command, but the example
 will not be tested if manual examples are run. It is the direct analog of
 &GAPDoc;'s <C>&lt;Log></C> (see <Ref Subsect="Log" BookName="gapdoc"/>).
@@ -472,7 +472,7 @@ The &AutoDoc; command <C>@LogSession</C> is an alias of <C>@BeginLogSession</C>.
 <Heading><C>@DoNotReadRestOfFile</C></Heading>
 
 <P/>
-<Index Key="@DoNotReadRestOfFile"><C>@DoNotReadRestOfFile</C></Index>
+<Index Key="@DoNotReadRestOfFile"><Code>@DoNotReadRestOfFile</Code></Index>
 Prevents the rest of the file from being read by the parser. Useful for
 unfinished or temporary files.
 <P/>
@@ -492,7 +492,7 @@ unfinished or temporary files.
 
 <P/>
 <Index Key="@BeginChunk"><C>@BeginChunk <A>name</A></C></Index>
-<Index Key="@EndChunk"><C>@EndChunk</C></Index>
+<Index Key="@EndChunk"><Code>@EndChunk</Code></Index>
 <Index Key="@EndChunk"><C>@InsertChunk <A>name</A></C></Index>
 Text inside a <C>@BeginChunk</C> / <C>@EndChunk</C> part will not be inserted into
 the final documentation directly. Instead, the text is stored in an internal buffer.
@@ -537,7 +537,7 @@ And then later, insert the example in a different file, like this:
 
 <P/>
 <Index Key="@BeginCode"><C>@BeginCode <A>name</A></C></Index>
-<Index Key="@EndCode"><C>@EndCode</C></Index>
+<Index Key="@EndCode"><Code>@EndCode</Code></Index>
 <Index Key="@InsertCode"><C>@InsertCode <A>name</A></C></Index>
 Inserts the text between <C>@BeginCode</C> and <C>@EndCode</C> verbatim at the point where
 <C>@InsertCode</C> is called. This is useful to insert code excerpts
@@ -559,8 +559,8 @@ i := i + 1;
 
 <P/>
 <Index Key="@LatexOnly"><C>@LatexOnly <A>text</A></C></Index>
-<Index Key="@BeginLatexOnly"><C>@BeginLatexOnly</C></Index>
-<Index Key="@EndLatexOnly"><C>@EndLatexOnly</C></Index>
+<Index Key="@BeginLatexOnly"><Code>@BeginLatexOnly</Code></Index>
+<Index Key="@EndLatexOnly"><Code>@EndLatexOnly</Code></Index>
 Code inserted between <C>@BeginLatexOnly</C> and <C>@EndLatexOnly</C> or after <C>@LatexOnly</C> is only inserted
 in the PDF version of the manual or worksheet. It can hold arbitrary &LaTeX;-commands.
 <Listing><![CDATA[
@@ -579,8 +579,8 @@ in the PDF version of the manual or worksheet. It can hold arbitrary &LaTeX;-com
 
 <P/>
 <Index Key="@NotLatex"><C>@NotLatex <A>text</A></C></Index>
-<Index Key="@BeginNotLatex"><C>@BeginNotLatex</C></Index>
-<Index Key="@EndNotLatex"><C>@EndNotLatex</C></Index>
+<Index Key="@BeginNotLatex"><Code>@BeginNotLatex</Code></Index>
+<Index Key="@EndNotLatex"><Code>@EndNotLatex</Code></Index>
 Code inserted between <C>@BeginNotLatex</C> and <C>@EndNotLatex</C> or after <C>@NotLatex</C> is inserted
 in the HTML and text versions of the manual or worksheet, but not in the PDF version.
 <Listing><![CDATA[
@@ -590,6 +590,23 @@ in the HTML and text versions of the manual or worksheet, but not in the PDF ver
 <P/>
 #! @NotLatex For further information see the PDF version of this manual.
 ]]></Listing>
+<P/>
+</Subsection>
+
+
+<Subsection Label="Subsection_@Index">
+<Heading><C>@Index <A>key</A> [<A>entry text</A>]</C></Heading>
+
+<P/>
+<Index Key="@Index"><C>@Index <A>key</A> [<A>entry text</A>]</C></Index>
+Adds an index entry to the current documentation text.
+The command <C>@Index key entry text</C> generates
+<C>&lt;Index Key="key"&gt;entry text&lt;/Index&gt;</C>.
+If no entry text is provided, then the entry text is empty.
+To use keys containing spaces, wrap the key in double quotes, e.g.
+<C>@Index "my key" entry text</C>.
+The entry text is processed like normal documentation text, so markdown-like
+inline code such as <Keyword>true</Keyword> is supported.
 <P/>
 </Subsection>
 

--- a/tst/manual.expected/_Chapter_Tutorials.xml
+++ b/tst/manual.expected/_Chapter_Tutorials.xml
@@ -357,13 +357,13 @@ Edit <File>PackageName/makedoc.g</File> as follows.
   In the <Code>AutoDoc</Code> record delete <Code>autodoc := true;</Code>. 
   </Item>
   <Item> 
-  <Index Key="Scaffold record in makedoc.g"></Index> 
+<Index Key="Scaffold record in makedoc.g"></Index>
   In the <Code>scaffold</Code> record change the <Code>includes</Code> list 
   to be the list of your <Code>.xml</Code> files that are contained in  
   <File>manual.xml</File>. 
   </Item> 
   <Item>
-  <Index Key="Bibliography field in makedoc.g"></Index> 
+<Index Key="Bibliography field in makedoc.g"></Index>
   If you do not have a bibliography you may delete the 
   <Code>bib := "bib.xml",</Code> field in the scaffold. 
   Otherwise, edit the file name if you have a different file. 
@@ -372,7 +372,7 @@ Edit <File>PackageName/makedoc.g</File> as follows.
   you should rename this file <File>PackageName.bib</File>. 
   </Item>
   <Item> 
-  <Index Key="LaTeXOptions record in makedoc.g"></Index>
+<Index Key="LaTeXOptions record in makedoc.g"></Index>
   In the <Code>LaTeXOptions</Code> record,
   which is in the <Code>gapdoc</Code> record, enter any
   &LaTeX; <Code>newcommands</Code> previously in <File>manual.xml</File>. 
@@ -399,9 +399,9 @@ Now edit <File>PackageName/PackageInfo.g</File> as follows.
   to the end of your file (just before the final <Code>"));"</Code>. 
   </Item>
   <Item> 
-  <Index Key="Copyright field in PackageInfo.g"></Index> 
-  <Index Key="Abstract field in PackageInfo.g"></Index> 
-  <Index Key="Acknowledgements field in PackageInfo.g"></Index> 
+<Index Key="Copyright field in PackageInfo.g"></Index>
+<Index Key="Abstract field in PackageInfo.g"></Index>
+<Index Key="Acknowledgements field in PackageInfo.g"></Index>
   Replace the <Code>Copyright</Code>, <Code>Abstract</Code> and 
   <Code>Acknowledgements</Code> fields of the <Code>TitlePage</Code> 
   record with the corresponding material from your <File>manual.xml</File>. 
@@ -411,7 +411,7 @@ Now edit <File>PackageName/PackageInfo.g</File> as follows.
 <!--  consult the file <File>gap/Magic.gd</File>. -->
   </Item>
   <Item> 
-  <Index Key="Entities record in makedoc.g"></Index> 
+<Index Key="Entities record in makedoc.g"></Index>
   In the <Code>entities</Code> record enter any entities 
   previously stored in your <File>manual.xml</File>. 
   (Again, if you have none, you may safely delete this record.) 

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -21,6 +21,10 @@ gap> Size(S5);
 
 
 Some text between two examples
+<Index Key="Worksheet Autoplain">Plain worksheet index entry with <Keyword>true</Keyword></Index>
+<Index Key="WorksheetAutoplainKeyOnly"></Index>
+<Index Key="A&amp;B">ampersand key</Index>
+<Index Key="A&lt;B">less-than key</Index>
 <Example><![CDATA[
 gap> A5 := AlternatingGroup(5);
 Alt( [ 1 .. 5 ] )

--- a/tst/worksheets/autoplain.expected/tst/plain_file.autodoc_test01.tst
+++ b/tst/worksheets/autoplain.expected/tst/plain_file.autodoc_test01.tst
@@ -16,7 +16,7 @@ Sym( [ 1 .. 5 ] )
 gap> Size(S5);
 120
 
-# _Chapter_Test.xml:24-29
+# _Chapter_Test.xml:28-33
 gap> A5 := AlternatingGroup(5);
 Alt( [ 1 .. 5 ] )
 gap> Size(A5);

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -13,6 +13,10 @@ gap> Size(S5);
 120
 @EndExampleSession
 Some text between two examples
+@Index "Worksheet Autoplain" Plain worksheet index entry with `true`
+@Index WorksheetAutoplainKeyOnly
+@Index A&B ampersand key
+@Index A<B less-than key
 @BeginExampleSession
 gap> A5 := AlternatingGroup(5);
 Alt( [ 1 .. 5 ] )

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -14,6 +14,10 @@ gap> Size(S5);
 
 
  Some text between two examples
+<Index Key="Worksheet General">General worksheet index entry with <Keyword>true</Keyword></Index>
+<Index Key="WorksheetGeneralKeyOnly"></Index>
+<Index Key="A&gt;B">greater-than key</Index>
+<Index Key="A&quot;B">quote key</Index>
 <Example><![CDATA[
 gap> A5 := AlternatingGroup(5);
 Alt( [ 1 .. 5 ] )

--- a/tst/worksheets/general.expected/tst/general_test01.tst
+++ b/tst/worksheets/general.expected/tst/general_test01.tst
@@ -16,7 +16,7 @@ Sym( [ 1 .. 5 ] )
 gap> Size(S5);
 120
 
-# _Chapter_SomeChapter.xml:17-25
+# _Chapter_SomeChapter.xml:21-29
 gap> A5 := AlternatingGroup(5);
 Alt( [ 1 .. 5 ] )
 gap> Size(A5);

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -17,6 +17,10 @@ Print( "(Even though we never use it that way.\n" );
 #! 120
 #! @EndExampleSession
 #! Some text between two examples
+#! @Index "Worksheet General" General worksheet index entry with `true`
+#! @Index WorksheetGeneralKeyOnly
+#! @Index A>B greater-than key
+#! @Index A"B quote key
 #! @BeginExampleSession
 #! gap> A5 := AlternatingGroup(5);
 #! Alt( [ 1 .. 5 ] )


### PR DESCRIPTION
Support @Index key [entry text] in AutoDoc comments and emit
<Index Key="key">entry text</Index> in generated XML.

If entry text is omitted, the key is used as the entry text.

Resolves #177

Co-authored-by: Codex <codex@openai.com>
