### PR TITLE
tests: move integration checks to worksheet fixtures

### DIFF
--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -109,41 +109,6 @@ gap> Scan_for_AutoDoc_Part( "  #! ## Comment section", false );
 [ "@Section", "Comment section" ]
 
 #
-# XML comments in .autodoc: pass through verbatim
-#
-gap> tmpdir := Filename(DirectoryTemporary(), "autodoc-xml-comment-test");;
-gap> if IsDirectoryPath(tmpdir) then RemoveDirectoryRecursively(tmpdir); fi;
-gap> AUTODOC_CreateDirIfMissing(tmpdir);
-true
-gap> tmpdir_obj := Directory(tmpdir);;
-gap> file1 := Filename(tmpdir_obj, "xml-comment.autodoc");;
-gap> stream := OutputTextFile(file1, false);;
-gap> AppendTo(stream, "@Chapter XML comments\n");;
-gap> AppendTo(stream, "@Section Intro\n");;
-gap> AppendTo(stream, "<!--\n");;
-gap> AppendTo(stream, "#  <#GAPDoc Label=\"ToricVarietyConst\">\n");;
-gap> AppendTo(stream, "#  <ManSection>\n");;
-gap> AppendTo(stream, "#  <#/GAPDoc>\n");;
-gap> AppendTo(stream, "-->\n");;
-gap> AppendTo(stream, "@Section After\n");;
-gap> CloseStream(stream);
-gap> tree6 := DocumentationTree();;
-gap> AutoDoc_Parser_ReadFiles([file1], tree6, rec());
-gap> WriteDocumentation(tree6, tmpdir_obj, 0);
-gap> files := DirectoryContents(tmpdir_obj);;
-gap> files := Filtered(files, f -> f <> "." and f <> ".." and PositionSublist(f, "_Chapter_") = 1);;
-gap> Sort(files);
-gap> files;
-[ "_Chapter_XML_comments.xml" ]
-gap> xml := StringFile(Filename(tmpdir_obj, "_Chapter_XML_comments.xml"));;
-gap> PositionSublist(xml, "<!--\n#  <#GAPDoc Label=\"ToricVarietyConst\">\n#  <ManSection>\n#  <#/GAPDoc>\n-->") <> fail;
-true
-gap> PositionSublist(xml, "Chapter_<#GAPDoc") = fail;
-true
-gap> RemoveDirectoryRecursively(tmpdir);
-true
-
-#
 # AutoDoc_Parser_ReadFiles: multiline InstallMethod parsing
 #
 gap> tree := DocumentationTree();;
@@ -211,34 +176,6 @@ gap> CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML([
 >   "#I  some log message",
 >   "]]></Log>"
 > ];
-true
-
-#
-# fenced code blocks preserve literal #! lines
-#
-gap> tmpdir := Filename(DirectoryTemporary(), "autodoc-fenced-comments-test");;
-gap> if IsDirectoryPath(tmpdir) then RemoveDirectoryRecursively(tmpdir); fi;
-gap> AUTODOC_CreateDirIfMissing(tmpdir);
-true
-gap> tmpdir_obj := Directory(tmpdir);;
-gap> file1 := Filename(tmpdir_obj, "fenced-comments.gd");;
-gap> stream := OutputTextFile(file1, false);;
-gap> AppendTo(stream, "#! @Chapter FenceChapter\n");;
-gap> AppendTo(stream, "#! @Section FenceSection\n");;
-gap> AppendTo(stream, "#! ```@listing\n");;
-gap> AppendTo(stream, "#! @Section ThisMustStayLiteral\n");;
-gap> AppendTo(stream, "#! #! AlsoLiteral\n");;
-gap> AppendTo(stream, "#! ```\n");;
-gap> CloseStream(stream);
-gap> tree5 := DocumentationTree();;
-gap> AutoDoc_Parser_ReadFiles([file1], tree5, rec());
-gap> WriteDocumentation(tree5, tmpdir_obj, 0);
-gap> xml := StringFile(Filename(tmpdir_obj, "_Chapter_FenceChapter.xml"));;
-gap> PositionSublist(xml, "<Listing><![CDATA[\n#! @Section ThisMustStayLiteral\n#! #! AlsoLiteral\n]]></Listing>") <> fail;
-true
-gap> PositionSublist(xml, "Section_ThisMustStayLiteral") = fail;
-true
-gap> RemoveDirectoryRecursively(tmpdir);
 true
 
 #

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -30,6 +30,12 @@ gap> Size(A5);
 
 
 Also, markdown-like inline <Keyword>true</Keyword> should become a keyword tag.
+And XML comments should pass through verbatim:
+<!--
+#  <#GAPDoc Label="ToricVarietyConst">
+#  <ManSection>
+#  <#/GAPDoc>
+-->
 And we wrap up with some dummy text
 </Subsection>
 

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -20,4 +20,10 @@ gap> Size(A5);
 60
 @EndExampleSession
 Also, markdown-like inline `true` should become a keyword tag.
+And XML comments should pass through verbatim:
+<!--
+#  <#GAPDoc Label="ToricVarietyConst">
+#  <ManSection>
+#  <#/GAPDoc>
+-->
 And we wrap up with some dummy text

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -107,6 +107,11 @@ This is <Keyword>true</Keyword> in a list item.
 </List>
 <P/>
  All of this can <Emph>also</Emph> be <Emph>used</Emph> outside of a <Code>list</Code>.
+ And fenced listings should preserve literal shebang-prefixed lines:
+<Listing><![CDATA[
+#! @Section ThisMustStayLiteral
+#! #! AlsoLiteral
+]]></Listing>
 <Alt Only="LaTeX"><![CDATA[
 This text will only appear in the \LaTeX version.
 ]]></Alt>

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -58,6 +58,11 @@ DeclareCategoryCollections("MyThingsCollection");
 #! * This is `true` in a list item.
 #!
 #! All of this can **also** be __used__ outside of a `list`.
+#! And fenced listings should preserve literal shebang-prefixed lines:
+#! ```@listing
+#! @Section ThisMustStayLiteral
+#! #! AlsoLiteral
+#! ```
 
 #! @LatexOnly This text will only appear in the \LaTeX version.
 #! @BeginLatexOnly


### PR DESCRIPTION
Move XML comment pass-through and fenced listing literal-shebang
coverage from tst/misc.tst into worksheet fixture inputs and
expected XML outputs.

Co-authored-by: Codex <codex@openai.com>
