### PR TITLE
Add read_example worksheet coverage

### DIFF
--- a/tst/worksheets.tst
+++ b/tst/worksheets.tst
@@ -8,7 +8,7 @@ gap> AUTODOC_TestWorkSheet("general");
 #I  Extracting manual examples for General Test package ...
 #I  2 chapters detected
 #I  Chapter 1...
-#I  extracted 2 examples
+#I  extracted 3 examples
 #I  Chapter 2...
 #I  no examples
 
@@ -17,7 +17,7 @@ gap> AUTODOC_TestWorkSheet("autoplain");
 #I  Extracting manual examples for Plain file.autodoc Test package ...
 #I  1 chapters detected
 #I  Chapter 1...
-#I  extracted 2 examples
+#I  extracted 3 examples
 
 #
 #

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -29,6 +29,13 @@ gap> Size(A5);
 ]]></Example>
 
 
+<Example><![CDATA[
+gap> plain_mode_value := 6 *
+>   9;
+54
+]]></Example>
+
+
 Also, markdown-like inline <Keyword>true</Keyword> should become a keyword tag.
 And we wrap up with some dummy text
 </Subsection>

--- a/tst/worksheets/autoplain.expected/tst/plain_file.autodoc_test01.tst
+++ b/tst/worksheets/autoplain.expected/tst/plain_file.autodoc_test01.tst
@@ -22,5 +22,10 @@ Alt( [ 1 .. 5 ] )
 gap> Size(A5);
 60
 
+# _Chapter_Test.xml:32-36
+gap> plain_mode_value := 6 *
+>   9;
+54
+
 #
 gap> STOP_TEST("plain_file.autodoc_test01.tst", 1);

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -19,5 +19,10 @@ Alt( [ 1 .. 5 ] )
 gap> Size(A5);
 60
 @EndExampleSession
+@BeginExample
+plain_mode_value := 6 *
+  9;
+#! 54
+@EndExample
 Also, markdown-like inline `true` should become a keyword tag.
 And we wrap up with some dummy text

--- a/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
+++ b/tst/worksheets/general.expected/_Chapter_SomeChapter.xml
@@ -25,6 +25,13 @@ true
 ]]></Example>
 
 
+<Example><![CDATA[
+gap> comment_mode_value := 6 *
+>   7;
+42
+]]></Example>
+
+
  And we wrap up with some dummy text
 <Section Label="Chapter_SomeChapter_Section_Some_categories">
 <Heading>Some categories</Heading>

--- a/tst/worksheets/general.expected/tst/general_test01.tst
+++ b/tst/worksheets/general.expected/tst/general_test01.tst
@@ -25,5 +25,10 @@ gap> # Test whether ]]> can be used safely
 gap> [[2]]>[[1]];
 true
 
+# _Chapter_SomeChapter.xml:28-32
+gap> comment_mode_value := 6 *
+>   7;
+42
+
 #
 gap> STOP_TEST("general_test01.tst", 1);

--- a/tst/worksheets/general.sheet/worksheet.g
+++ b/tst/worksheets/general.sheet/worksheet.g
@@ -26,6 +26,11 @@ Print( "(Even though we never use it that way.\n" );
 #! gap> [[2]]>[[1]];
 #! true
 #! @EndExampleSession
+#! @BeginExample
+comment_mode_value := 6 *
+  7;
+#! 42
+#! @EndExample
 #! And we wrap up with some dummy text
 
 #############################################################################


### PR DESCRIPTION
Cover read_example in both worksheet parser modes by
adding @BeginExample blocks to the existing general and
autoplain fixtures.

Co-authored-by: Codex <codex@openai.com>
