### PR TITLE
Remove autodoc.section_intros

### DIFF
--- a/gap/AutoDocMainFunction.gd
+++ b/gap/AutoDocMainFunction.gd
@@ -16,7 +16,6 @@ BindGlobal( "AUTODOC_XML_HEADER",
 DeclareGlobalFunction( "AUTODOC_SetIfMissing" );
 DeclareGlobalFunction( "AUTODOC_APPEND_STRING_ITERATIVE" );
 DeclareGlobalFunction( "AUTODOC_MergeRecords" );
-DeclareGlobalFunction( "AUTODOC_PROCESS_INTRO_STRINGS" );
 DeclareGlobalFunction( "AutoDocScanFiles" );
 
 ## Global option record

--- a/gap/AutoDocMainFunction.gi
+++ b/gap/AutoDocMainFunction.gi
@@ -289,36 +289,6 @@ InstallGlobalFunction( CreateTitlePage,
     CloseStream( filestream );
 end );
 
-InstallGlobalFunction( AUTODOC_PROCESS_INTRO_STRINGS,
-  function( introduction_list, tree )
-    local intro, intro_string, i;
-
-    for intro in introduction_list do
-        if Length( intro ) = 2 then
-            intro_string := intro[ 2 ];
-            if IsString( intro_string ) then
-                intro_string := [ intro_string ];
-            fi;
-            for i in intro_string do
-                Add( ChapterInTree( tree, ReplacedString( intro[ 1 ], " ", "_" ) ), i );
-            od;
-        elif Length( intro ) = 3 then
-            intro_string := intro[ 3 ];
-            if IsString( intro_string ) then
-                intro_string := [ intro_string ];
-            fi;
-            for i in intro_string do
-                Add( SectionInTree( tree, ReplacedString( intro[ 1 ], " ", "_" ),
-                                          ReplacedString( intro[ 2 ], " ", "_" ) ), i );
-            od;
-        else
-            Error( "wrong format of introduction string list\n" );
-        fi;
-    od;
-
-    return tree;
-end );
-
 ##
 ## Optional argument is PackageName, which creates a
 ## Default chapter record. This is not available for

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -261,15 +261,6 @@
 #!             they will not be printed into the manual.
 #!         </Item>
 #!
-#### TODO: Document section_intros later on.
-#### However, note that thanks to the new AutoDoc comment syntax, the only remaining
-#### use for this seems to be the ability to specify the order of chapters and
-#### sections.
-####                 <Mark><A>section_intros</A></Mark>
-####                 <Item>
-####                     TODO.
-####                 </Item>
-#!
 #!         </List>
 #!     </Item>
 #!

--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -366,10 +366,6 @@ function( arg )
     tree := DocumentationTree( );
 
     if IsBound( autodoc ) then
-        if IsBound( autodoc.section_intros ) then
-            AUTODOC_PROCESS_INTRO_STRINGS( autodoc.section_intros, tree );
-        fi;
-
         AutoDocScanFiles( autodoc.files, pkgname, tree );
     fi;
 

--- a/gap/Markdown.gi
+++ b/gap/Markdown.gi
@@ -80,14 +80,12 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
                          ReplacedString( string_list[ i ], "]]>", "]]]]><![CDATA[>" ) );
                     i := i + 1;
                 od;
+                Add( converted_string_list,
+                     Concatenation( "]]></", fence_element, ">" ) );
                 if code_block = true then
-                    Add( converted_string_list,
-                         Concatenation( "]]></", fence_element, ">" ) );
                     i := i + 1;
                     continue;
                 fi;
-                Add( converted_string_list,
-                     Concatenation( "]]></", fence_element, ">" ) );
                 break;
             fi;
         fi;


### PR DESCRIPTION
These are remnants from prehistoric AutoDoc versions, used by our ancestors.

Also reduce code duplication.
