### PR TITLE
Preserve blank lines in fenced code blocks

### DIFF
--- a/gap/DocumentationTree.gi
+++ b/gap/DocumentationTree.gi
@@ -507,7 +507,7 @@ end );
 ##
 InstallMethod( WriteDocumentation, [ IsList, IsStream, IsInt ],
   function( node_list, filestream, level_value )
-    local current_string_list, i, last_position;
+    local current_string_list, i, last_position, in_cdata, line;
 
     i := 1;
     current_string_list := [ ];
@@ -517,7 +517,20 @@ InstallMethod( WriteDocumentation, [ IsList, IsStream, IsInt ],
         else
             if current_string_list <> [ ] then
                 current_string_list := CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML( current_string_list );
-                Perform( current_string_list, function( i ) WriteDocumentation( i, filestream, level_value ); end );
+                in_cdata := false;
+                for line in current_string_list do
+                    if PositionSublist( line, "<![CDATA[" ) <> fail then
+                        in_cdata := true;
+                    fi;
+                    if in_cdata = true then
+                        AppendTo( filestream, Chomp( line ), "\n" );
+                    else
+                        WriteDocumentation( line, filestream, level_value );
+                    fi;
+                    if PositionSublist( line, "]]>" ) <> fail then
+                        in_cdata := false;
+                    fi;
+                od;
                 current_string_list := [ ];
             fi;
             WriteDocumentation( node_list[ i ], filestream, level_value );
@@ -526,7 +539,20 @@ InstallMethod( WriteDocumentation, [ IsList, IsStream, IsInt ],
     od;
     if current_string_list <> [ ] then
         current_string_list := CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML( current_string_list );
-        Perform( current_string_list, function( i ) WriteDocumentation( i, filestream, level_value ); end );
+        in_cdata := false;
+        for line in current_string_list do
+            if PositionSublist( line, "<![CDATA[" ) <> fail then
+                in_cdata := true;
+            fi;
+            if in_cdata = true then
+                AppendTo( filestream, Chomp( line ), "\n" );
+            else
+                WriteDocumentation( line, filestream, level_value );
+            fi;
+            if PositionSublist( line, "]]>" ) <> fail then
+                in_cdata := false;
+            fi;
+        od;
     fi;
 end );
 

--- a/gap/Markdown.gi
+++ b/gap/Markdown.gi
@@ -97,14 +97,21 @@ InstallGlobalFunction( CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML,
     ## Check for paragraphs by turning an empty string into <P/>
     
     already_inserted_paragraph := false;
+    skipped := false;
     for i in [ 1 ..  Length( string_list ) ] do
-        if NormalizedWhitespace( string_list[ i ] ) = "" then
+        if PositionSublist( string_list[ i ], "<![CDATA[" ) <> fail then
+            skipped := true;
+        fi;
+        if skipped = false and NormalizedWhitespace( string_list[ i ] ) = "" then
             if already_inserted_paragraph = false then
                 string_list[ i ] := "<P/>";
                 already_inserted_paragraph := true;
             fi;
         else
             already_inserted_paragraph := false;
+        fi;
+        if PositionSublist( string_list[ i ], "]]>" ) <> fail then
+            skipped := false;
         fi;
         i := i + 1;
     od;

--- a/tst/manual.expected/_Chapter_Comments.xml
+++ b/tst/manual.expected/_Chapter_Comments.xml
@@ -312,10 +312,10 @@ Ends the current group.
 #!
 DeclareAttribute( "GroupedAttribute",
                   IsList );
-<P/>
+
 DeclareOperation( "NonGroupedOperation",
                   [ IsObject ] );
-<P/>
+
 #!
 DeclareOperation( "GroupedOperation",
                   [ IsList, IsRubbish ] );
@@ -478,9 +478,9 @@ unfinished or temporary files.
 <P/>
 <Listing><![CDATA[
 #! This will appear in the manual
-<P/>
+
 #! @DoNotReadRestOfFile
-<P/>
+
 #! This will not appear in the manual.
 ]]></Listing>
 <P/>
@@ -505,7 +505,7 @@ If you do not provide an <C>@EndChunk</C>, the chunk ends at the end of the file
 #! @BeginChunk MyChunk
 #! Hello, world.
 #! @EndChunk
-<P/>
+
 #! @InsertChunk MyChunk
 ## The text "Hello, world." is inserted right before this.
 ]]></Listing>
@@ -546,7 +546,7 @@ directly into the manual.
 #! @BeginCode Increment
 i := i + 1;
 #! @EndCode
-<P/>
+
 #! @InsertCode Increment
 ## Code is inserted here.
 ]]></Listing>
@@ -567,7 +567,7 @@ in the PDF version of the manual or worksheet. It can hold arbitrary &LaTeX;-com
 #! @BeginLatexOnly
 #! \include{picture.tex}
 #! @EndLatexOnly
-<P/>
+
 #! @LatexOnly \include{picture.tex}
 ]]></Listing>
 <P/>
@@ -587,7 +587,7 @@ in the HTML and text versions of the manual or worksheet, but not in the PDF ver
 #! @BeginNotLatex
 #! For further information see the PDF version of this manual.
 #! @EndNotLatex
-<P/>
+
 #! @NotLatex For further information see the PDF version of this manual.
 ]]></Listing>
 <P/>
@@ -703,19 +703,19 @@ The following code
 <Listing><![CDATA[
 #! @BeginGroup Group1
 #! @GroupTitle A family of operations
-<P/>
+
 #! @Description
 #!  First sentence.
 DeclareOperation( "FirstOperation", [ IsInt ] );
-<P/>
+
 #! @Description
 #!  Second sentence.
 DeclareOperation( "SecondOperation", [ IsInt, IsGroup ] );
-<P/>
+
 #! @EndGroup
-<P/>
+
 ## .. Stuff ..
-<P/>
+
 #! @Description
 #!  Third sentence.
 #! @Group Group1

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -175,6 +175,51 @@ gap> CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML([
 >   "]]></Log>"
 > ];
 true
+gap> CONVERT_LIST_OF_STRINGS_IN_MARKDOWN_TO_GAPDOC_XML([
+>   "```@listing",
+>   "#! @BeginCode Increment",
+>   "i := i + 1;",
+>   "#! @EndCode",
+>   "",
+>   "#! @InsertCode Increment",
+>   "## Code is inserted here.",
+>   "```"
+> ]) = [
+>   "<Listing><![CDATA[",
+>   "#! @BeginCode Increment",
+>   "i := i + 1;",
+>   "#! @EndCode",
+>   "",
+>   "#! @InsertCode Increment",
+>   "## Code is inserted here.",
+>   "]]></Listing>"
+> ];
+true
+gap> rendered := "";;
+gap> stream := OutputTextString(rendered, true);;
+gap> SetPrintFormattingStatus(stream, false);
+gap> WriteDocumentation([
+>   "```@listing",
+>   "#! @BeginCode Increment",
+>   "i := i + 1;",
+>   "#! @EndCode",
+>   "",
+>   "#! @InsertCode Increment",
+>   "## Code is inserted here.",
+>   "```"
+> ], stream, 0);
+gap> CloseStream(stream);
+gap> rendered = Concatenation(
+>   "<Listing><![CDATA[\n",
+>   "#! @BeginCode Increment\n",
+>   "i := i + 1;\n",
+>   "#! @EndCode\n",
+>   "\n",
+>   "#! @InsertCode Increment\n",
+>   "## Code is inserted here.\n",
+>   "]]></Listing>\n"
+> );
+true
 
 #
 # warn about defined-but-never-inserted chunks


### PR DESCRIPTION
Preserve blank lines inside fenced CDATA blocks.

Add regression tests for conversion and rendered output.

Co-authored-by: Codex <codex@openai.com>
