### PR TITLE
CI: upload manual PDF directly, not wrapped into a zip

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           use-latex: 'true'
       - name: 'Upload documentation'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: manual
+          archive: false
           path: ./doc/manual.pdf
           if-no-files-found: error


### PR DESCRIPTION
Let's try this here; see https://github.com/gap-actions/build-pkg-docs/pull/44

CC @stertoy @limakzi 