### PR TITLE
manual: document nopdf and relativePath options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ This file describes changes in the AutoDoc package.
     documented. Since nobody ever reported issues with them, and since
     no distributed packages uses them, they probably are simply not in
     use anywhere. Hence the removal instead of trying to fix this.
+  - Add `nopdf` as a global option, and document the existing `NOPDF`
+    environment variable and `relativePath` global option
   - Add Markdown-style headings `#`/`##`/`###` as aliases for
     `@Chapter`/`@Section`/`@Subsection` in `.autodoc` files and doc comments
   - Add fenced code blocks using triple backticks or tildes in

--- a/doc/Tutorials.autodoc
+++ b/doc/Tutorials.autodoc
@@ -313,6 +313,45 @@ LoadPackage( "AutoDoc" );
 AutoDoc( rec( gapdoc := rec( gap_root_relative_path := true ) ) );
 ```
 
+The same behavior is also available via the global option
+`relativePath`. This is particularly convenient in a short
+<F>makedoc.g</F> script, and it overrides `gapdoc.gap_root_relative_path`
+if both are given. Since this is a GAP global option, you can also set it
+outside the eventual <Ref Func="AutoDoc"/> call and let it propagate through
+nested calls; see <Ref Chap="Options Stack" BookName="ref"/> for more
+information about GAP's global options system:
+```@listing
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( autodoc := true ) : relativePath := "../../.." );
+```
+If you pass `relativePath := true`, then &AutoDoc; uses the default
+relative path <F>../../..</F>.
+
+For example, if your <F>makedoc.g</F> reads the manual via
+<Ref Func="AutoDoc"/>, then the following command sets both
+`relativePath` and `nopdf` to `true` for that nested call:
+```@listing
+Read( "makedoc.g" : nopdf, relativePath );
+```
+
+Finally, if you only want HTML and text output, you can suppress PDF
+generation with the global option `nopdf`:
+```@listing
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( autodoc := true ) : nopdf );
+```
+This is useful if `pdflatex` is unavailable, or when you want a faster
+documentation rebuild while editing.
+
+You can also request the same behavior from the shell by setting the
+environment variable `NOPDF` before invoking <F>makedoc.g</F>. For
+example:
+```@listing
+NOPDF=1 gap makedoc.g
+```
+If `NOPDF` is set, &AutoDoc; skips PDF generation even if no
+`nopdf` option is given in the GAP code.
+
 @Subsection Checklist for converting an existing &GAPDoc; manual to use &AutoDoc;
 @SubsectionLabel Tut:Checklist
 

--- a/gap/Magic.gd
+++ b/gap/Magic.gd
@@ -350,6 +350,7 @@
 #!
 #!         </List>
 #!     </Item>
+#!
 #!     <Mark><A>extract_examples</A></Mark>
 #!     <Item>
 #!         Either <K>true</K> or a record.
@@ -386,6 +387,49 @@
 #!     </List>
 #! </Item>
 #! </List>
+#!
+#! The function also checks the following GAP global options, i.e. options
+#! supplied via GAP's value-option syntax and visible through nested calls.
+#! These are not entries of <A>optrec</A>. See
+#! <Ref Chap="Options Stack" BookName="ref"/> for more information
+#! about GAP's global options system.
+#! <List>
+#! <Mark><A>nopdf</A></Mark>
+#! <Item>
+#!     If this global option is set to `true`, then &AutoDoc; tells &GAPDoc;
+#!     not to build the PDF version of the manual. HTML and text output are
+#!     still generated.
+#!     <P/>
+#!     This is useful on systems without a working `pdflatex`
+#!     installation, or when you only need the non-PDF outputs while
+#!     iterating on the manual.
+#!     <P/>
+#!     For example:
+#!     <Listing><![CDATA[
+#!     AutoDoc( rec( autodoc := true ) : nopdf );]]></Listing>
+#!     Also, if the environment variable `NOPDF` is set, then &AutoDoc;
+#!     behaves as if the global option <A>nopdf</A> had been enabled.
+#! </Item>
+#! <Mark><A>relativePath</A></Mark>
+#! <Item>
+#!     This has the same effect as <A>gapdoc.gap_root_relative_path</A>, but
+#!     as a GAP global option. It takes precedence over that record entry if
+#!     both are specified.
+#!     <P/>
+#!     If <A>relativePath</A> is `true`, then the default relative path
+#!     <F>../../..</F> is used. If it is a string, then that string is used as
+#!     the relative path from the documentation directory to the GAP root.
+#!     <P/>
+#!     For example:
+#!     <Listing><![CDATA[
+#!     AutoDoc( rec( autodoc := true ) : relativePath := "../../.." );]]></Listing>
+#! </Item>
+#! </List>
+#! In particular, a call such as
+#! <Listing><![CDATA[
+#! Read( "makedoc.g" : nopdf, relativePath );]]></Listing>
+#! sets both global options to `true`, and they remain visible to the
+#! <Ref Func="AutoDoc"/> call inside <F>makedoc.g</F>.
 #!
 #! @Returns nothing
 #! @Arguments [packageOrDirectory], [optrec]

--- a/tst/manual.expected/_Chapter_Reference.xml
+++ b/tst/manual.expected/_Chapter_Reference.xml
@@ -383,6 +383,49 @@
  </Item>
  </List>
 <P/>
+ The function also checks the following GAP global options, i.e. options
+ supplied via GAP's value-option syntax and visible through nested calls.
+ These are not entries of <A>optrec</A>. See
+ <Ref Chap="Options Stack" BookName="ref"/> for more information
+ about GAP's global options system.
+ <List>
+ <Mark><A>nopdf</A></Mark>
+ <Item>
+     If this global option is set to <Keyword>true</Keyword>, then &AutoDoc; tells &GAPDoc;
+     not to build the PDF version of the manual. HTML and text output are
+     still generated.
+     <P/>
+     This is useful on systems without a working <Code>pdflatex</Code>
+     installation, or when you only need the non-PDF outputs while
+     iterating on the manual.
+     <P/>
+     For example:
+     <Listing><![CDATA[
+     AutoDoc( rec( autodoc := true ) : nopdf );]]></Listing>
+     Also, if the environment variable <Code>NOPDF</Code> is set, then &AutoDoc;
+     behaves as if the global option <A>nopdf</A> had been enabled.
+ </Item>
+ <Mark><A>relativePath</A></Mark>
+ <Item>
+     This has the same effect as <A>gapdoc.gap_root_relative_path</A>, but
+     as a GAP global option. It takes precedence over that record entry if
+     both are specified.
+     <P/>
+     If <A>relativePath</A> is <Keyword>true</Keyword>, then the default relative path
+     <F>../../..</F> is used. If it is a string, then that string is used as
+     the relative path from the documentation directory to the GAP root.
+     <P/>
+     For example:
+     <Listing><![CDATA[
+     AutoDoc( rec( autodoc := true ) : relativePath := "../../.." );]]></Listing>
+ </Item>
+ </List>
+ In particular, a call such as
+ <Listing><![CDATA[
+ Read( "makedoc.g" : nopdf, relativePath );]]></Listing>
+ sets both global options to <Keyword>true</Keyword>, and they remain visible to the
+ <Ref Func="AutoDoc"/> call inside <F>makedoc.g</F>.
+<P/>
  </Description>
 </ManSection>
 

--- a/tst/manual.expected/_Chapter_Tutorials.xml
+++ b/tst/manual.expected/_Chapter_Tutorials.xml
@@ -336,6 +336,45 @@ LoadPackage( "AutoDoc" );
 AutoDoc( rec( gapdoc := rec( gap_root_relative_path := true ) ) );
 ]]></Listing>
 <P/>
+The same behavior is also available via the global option
+<Code>relativePath</Code>. This is particularly convenient in a short
+<F>makedoc.g</F> script, and it overrides <Code>gapdoc.gap_root_relative_path</Code>
+if both are given. Since this is a GAP global option, you can also set it
+outside the eventual <Ref Func="AutoDoc"/> call and let it propagate through
+nested calls; see <Ref Chap="Options Stack" BookName="ref"/> for more
+information about GAP's global options system:
+<Listing><![CDATA[
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( autodoc := true ) : relativePath := "../../.." );
+]]></Listing>
+If you pass <Code>relativePath := true</Code>, then &AutoDoc; uses the default
+relative path <F>../../..</F>.
+<P/>
+For example, if your <F>makedoc.g</F> reads the manual via
+<Ref Func="AutoDoc"/>, then the following command sets both
+<Code>relativePath</Code> and <Code>nopdf</Code> to <Keyword>true</Keyword> for that nested call:
+<Listing><![CDATA[
+Read( "makedoc.g" : nopdf, relativePath );
+]]></Listing>
+<P/>
+Finally, if you only want HTML and text output, you can suppress PDF
+generation with the global option <Code>nopdf</Code>:
+<Listing><![CDATA[
+LoadPackage( "AutoDoc" );
+AutoDoc( rec( autodoc := true ) : nopdf );
+]]></Listing>
+This is useful if <Code>pdflatex</Code> is unavailable, or when you want a faster
+documentation rebuild while editing.
+<P/>
+You can also request the same behavior from the shell by setting the
+environment variable <Code>NOPDF</Code> before invoking <F>makedoc.g</F>. For
+example:
+<Listing><![CDATA[
+NOPDF=1 gap makedoc.g
+]]></Listing>
+If <Code>NOPDF</Code> is set, &AutoDoc; skips PDF generation even if no
+<Code>nopdf</Code> option is given in the GAP code.
+<P/>
 </Subsection>
 
 <Subsection Label="Subsection_Tut:Checklist">


### PR DESCRIPTION
Document the global nopdf and relativePath options in the AutoDoc
reference and tutorial, and describe the NOPDF environment
variable for skipping PDF generation.

AI assistance: Codex prepared the documentation updates and
regenerated the manual test fixtures.

Fixes #156

Co-authored-by: Codex <codex@openai.com>
