### PR TITLE
Add @ItemType for InstallMethod docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@ This file describes changes in the AutoDoc package.
     `@Command` does not start at column 1
   - Normalize parsed `InstallMethod` names by stripping surrounding
     quotes, matching `Declare...` handling
+  - Document `InstallMethod` support in declaration comments and add
+    `@ItemType` to override whether an installed method should be
+    documented as `Func`, `Oper`, `Attr`, or `Prop`
   - Loosen requirements on `@Date` command: this used to allow free form,
     but in recent versions was restricted to dates of the form YYYY-MM-DD
     or DD/MM/YYYY; now we again allow any text, but text in those specific

--- a/doc/Comments.autodoc
+++ b/doc/Comments.autodoc
@@ -22,6 +22,10 @@ immediately after the &AutoDoc; comment block. In particular, do not insert
 other code (such as <C>if false then</C> or assignments) between the comment
 block and the <C>Declare...</C> statement.
 
+This also works for <C>InstallMethod</C> and <C>InstallOtherMethod</C>.
+In that case, &AutoDoc; uses the installed method's name and filter list to
+create a manual entry for the implemented item.
+
 Inside of &AutoDoc; comments, <E>&AutoDoc; commands</E>
 starting with <C>@</C> can be used to control the output &AutoDoc; produces.
 Any comment line that does <E>not</E> start with an &AutoDoc; command is treated
@@ -75,6 +79,31 @@ brackets. The argument names can be separated by whitespace, commas or
 square brackets for the optional arguments, like <Q>grp[, elm]</Q> or
 <Q>xx[y[z] ]</Q>. If &GAP; options are used, this can be followed by a colon :
 and one or more assignments, like <Q>n[, r]: tries := 100</Q>.
+
+@Subsection <C>@ItemType <A>kind</A></C>
+@SubsectionLabel @ItemType
+
+@Index "@ItemType" <C>@ItemType <A>kind</A></C>
+Overrides the kind of manual item created for the following declaration or
+installed method. The supported values are <C>Func</C>, <C>Oper</C>,
+<C>Attr</C>, and <C>Prop</C>.
+
+This is mainly useful for <C>InstallMethod</C>. For a declaration such as
+<C>DeclareAttribute</C> or <C>DeclareProperty</C>, &AutoDoc; already knows the
+correct item type from the declaration itself. But for <C>InstallMethod</C>,
+especially with one argument, the source code alone does not reliably tell
+whether the method belongs to an operation, an attribute, a property, or even
+a plain function. Without an override, such entries default to <C>Oper</C>.
+
+For example:
+
+```@listing
+#! @ItemType Attr
+InstallMethod( SomeAttribute, [ IsGroup ], G -> G );
+```
+
+This makes &AutoDoc; emit an <C>&lt;Attr .../&gt;</C> manual entry instead of
+the default <C>&lt;Oper .../&gt;</C>.
 
 @Subsection <C>@Group <A>grpname</A></C>
 @SubsectionLabel @Group

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -216,7 +216,8 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
           ReadLineWithLineCount, NormalizedReadLine, line_number, ErrorWithPos, CreateTitleItemFunction,
           current_line_positition_for_filter, ReadSessionExample, DeclarationDelimiterPosition,
           ReadBracketedFilterString, ReadInstallMethodFilterString, ReadInstallMethodArguments,
-          ApplyFilterInfoToCurrentItem, ScanDeclarePart, ScanInstallMethodPart,
+          ApplyFilterInfoToCurrentItem, NormalizeItemType, ScanDeclarePart,
+          ScanInstallMethodPart,
           markdown_fence,
           MarkdownFenceFromLine, IsMatchingMarkdownFence,
           current_line_fence, current_line_is_fence_delimiter,
@@ -419,6 +420,18 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             fi;
         fi;
     end;
+    NormalizeItemType := function( item_type )
+        item_type := StripBeginEnd( item_type, " \t\r\n" );
+        if item_type in [ "Func", "Oper", "Attr", "Prop" ] then
+            return item_type;
+        fi;
+        ErrorWithPos(
+            Concatenation(
+                "unknown @ItemType ", item_type,
+                "; expected one of Func, Oper, Attr, Prop"
+            )
+        );
+    end;
     CurrentOrNewManItem := function( )
         local man_item;
         if HasCurrentItem() and IsTreeForDocumentationNodeForManItemRep( CurrentItem() ) then
@@ -534,7 +547,13 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
     ScanInstallMethodPart := function( declare_position )
         local filter_string, name, pos;
         CurrentOrNewManItem();
-        CurrentItem()!.item_type := "Oper";
+        if not IsBound( CurrentItem()!.item_type ) then
+            CurrentItem()!.item_type := "Oper";
+        else
+            CurrentItem()!.item_type := NormalizeItemType(
+                CurrentItem()!.item_type
+            );
+        fi;
         pos := PositionSublist( current_line, "(" );
         current_line := current_line{ [ pos + 1 .. Length( current_line ) ] };
         name := "";
@@ -794,6 +813,10 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         @Arguments := function()
             CurrentOrNewManItem();
             CurrentItem()!.arguments := current_command[ 2 ];
+        end,
+        @ItemType := function()
+            CurrentOrNewManItem();
+            CurrentItem()!.item_type := NormalizeItemType( current_command[ 2 ] );
         end,
         @Label := function()
             CurrentOrNewManItem();

--- a/tst/AutoDocTest/gap/AutoDocTest.gi
+++ b/tst/AutoDocTest/gap/AutoDocTest.gi
@@ -18,12 +18,15 @@ end );
 
 #!
 #! The method for `AutoDocTest_Operation` returns the second argument.
+#! @ItemType Oper
 InstallMethod( AutoDocTest_Operation, [ IsGroup, IsPosInt ], { G, n } -> n );
 
 #!
 #! The attribute method simply returns the group itself.
+#! @ItemType Attr
 InstallMethod( AutoDocTest_Attribute, [ IsSolvableGroup ], G -> G );
 
 #!
 #! The property method reuses `IsAbelian` for nilpotent groups.
+#! @ItemType Prop
 InstallMethod( AutoDocTest_Property, [ IsNilpotentGroup ], IsAbelian );

--- a/tst/AutoDocTest/tst/manual.expected/_Chapter_SourceAPI.xml
+++ b/tst/AutoDocTest/tst/manual.expected/_Chapter_SourceAPI.xml
@@ -65,7 +65,7 @@
 <P/>
  The attribute method simply returns the group itself.
 <ManSection>
-  <Oper Arg="arg1" Name="AutoDocTest_Attribute" Label="for IsSolvableGroup"/>
+  <Attr Arg="arg1" Name="AutoDocTest_Attribute" Label="for IsSolvableGroup"/>
  <Description>
 <P/>
  </Description>
@@ -74,7 +74,7 @@
 <P/>
  The property method reuses <Code>IsAbelian</Code> for nilpotent groups.
 <ManSection>
-  <Oper Arg="arg1" Name="AutoDocTest_Property" Label="for IsNilpotentGroup"/>
+  <Prop Arg="arg1" Name="AutoDocTest_Property" Label="for IsNilpotentGroup"/>
  <Description>
 <P/>
  </Description>

--- a/tst/autodoc-parser-installmethod.g
+++ b/tst/autodoc-parser-installmethod.g
@@ -1,5 +1,6 @@
 #! @Chapter Parser
 #! @Section InstallMethod
+#! @ItemType Func
 InstallMethod( "MyOp",
                [ IsInt,
                  IsString ],

--- a/tst/errorwithpos.tst
+++ b/tst/errorwithpos.tst
@@ -88,6 +88,9 @@ at tst/errorwithpos/installmethod-unterminated-declaration.g:4
 gap> ParseFixture( "tst/errorwithpos/installmethod-unterminated-arguments.g" );
 Error, unterminated argument list in InstallMethod declaration,
 at tst/errorwithpos/installmethod-unterminated-arguments.g:4
+gap> ParseFixture( "tst/errorwithpos/itemtype-unknown.g" );
+Error, unknown @ItemType Method; expected one of Func, Oper, Attr, Prop,
+at tst/errorwithpos/itemtype-unknown.g:3
 
 #
 # GroupTitle, Index, BREAK, and unknown command errors

--- a/tst/errorwithpos/itemtype-unknown.g
+++ b/tst/errorwithpos/itemtype-unknown.g
@@ -1,0 +1,4 @@
+#! @Chapter Parser
+#! @Section InvalidItemType
+#! @ItemType Method
+InstallMethod( "Broken", [ IsObject ], obj -> obj );

--- a/tst/manual.expected/_Chapter_Comments.xml
+++ b/tst/manual.expected/_Chapter_Comments.xml
@@ -25,6 +25,10 @@ immediately after the &AutoDoc; comment block. In particular, do not insert
 other code (such as <C>if false then</C> or assignments) between the comment
 block and the <C>Declare...</C> statement.
 <P/>
+This also works for <C>InstallMethod</C> and <C>InstallOtherMethod</C>.
+In that case, &AutoDoc; uses the installed method's name and filter list to
+create a manual entry for the implemented item.
+<P/>
 Inside of &AutoDoc; comments, <E>&AutoDoc; commands</E>
 starting with <C>@</C> can be used to control the output &AutoDoc; produces.
 Any comment line that does <E>not</E> start with an &AutoDoc; command is treated
@@ -86,6 +90,34 @@ brackets. The argument names can be separated by whitespace, commas or
 square brackets for the optional arguments, like <Q>grp[, elm]</Q> or
 <Q>xx[y[z] ]</Q>. If &GAP; options are used, this can be followed by a colon :
 and one or more assignments, like <Q>n[, r]: tries := 100</Q>.
+<P/>
+</Subsection>
+
+<Subsection Label="Subsection_@ItemType">
+<Heading><C>@ItemType <A>kind</A></C></Heading>
+
+<P/>
+<Index Key="@ItemType"><C>@ItemType <A>kind</A></C></Index>
+Overrides the kind of manual item created for the following declaration or
+installed method. The supported values are <C>Func</C>, <C>Oper</C>,
+<C>Attr</C>, and <C>Prop</C>.
+<P/>
+This is mainly useful for <C>InstallMethod</C>. For a declaration such as
+<C>DeclareAttribute</C> or <C>DeclareProperty</C>, &AutoDoc; already knows the
+correct item type from the declaration itself. But for <C>InstallMethod</C>,
+especially with one argument, the source code alone does not reliably tell
+whether the method belongs to an operation, an attribute, a property, or even
+a plain function. Without an override, such entries default to <C>Oper</C>.
+<P/>
+For example:
+<P/>
+<Listing><![CDATA[
+#! @ItemType Attr
+InstallMethod( SomeAttribute, [ IsGroup ], G -> G );
+]]></Listing>
+<P/>
+This makes &AutoDoc; emit an <C>&lt;Attr .../&gt;</C> manual entry instead of
+the default <C>&lt;Oper .../&gt;</C>.
 <P/>
 </Subsection>
 

--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -114,7 +114,7 @@ gap> AutoDoc_Parser_ReadFiles( [ "tst/autodoc-parser-installmethod.g" ], tree, r
 gap> section := SectionInTree( tree, "Parser", "InstallMethod" );;
 gap> item := section!.content[ 1 ];;
 gap> item!.item_type;
-"Oper"
+"Func"
 gap> item!.name;
 "MyOp"
 gap> item!.tester_names;


### PR DESCRIPTION
Allow declaration comments to override the manual item kind for
InstallMethod entries via @ItemType using the GAP and GAPDoc
abbreviations Func, Oper, Attr, and Prop. Document InstallMethod
support in declaration comments and add regression coverage for
the new override and invalid values.

AI assistance disclosure: Codex assisted with implementing the
parser change, updating the manual text, and extending the test
fixtures and expected output.

Co-authored-by: Codex <codex@openai.com>
