### PR TITLE
Look for GAP/autodoc files in pkgdir first, and in the current directory second

### DIFF
--- a/gap/Magic.gi
+++ b/gap/Magic.gi
@@ -228,11 +228,11 @@ function( is_worksheet, pkgname, pkginfo, pkgdir, opt )
         # Make sure all of the files exist, making the file names absolute if
         # necessary
         for i in [ 1 .. Length( autodoc.files ) ] do
-            if IsExistingFile( autodoc.files[ i ] ) then continue; fi;
             if IsExistingFile( Filename( pkgdir, autodoc.files[ i ] ) ) then
                 autodoc.files[ i ] := Filename( pkgdir, autodoc.files[ i ] );
                 continue;
             fi;
+            if IsExistingFile( autodoc.files[ i ] ) then continue; fi;
             Error( autodoc.files[ i ], " does not specify an existing file either as an absolute path or relative to the package directory" );
         od;
 


### PR DESCRIPTION
This prevents problems in the rare case where we are calling a `makedoc.g` script from outside the package's directory, but the current directory has a file with the same *relative* path as one of the files used in the documentation.

For example, this can happen by calling `makedoc ../packageA/makedoc.g` from within Package B's directory (this is actually how I encountered the problem). And that's not an entirely unreasonable thing to do, since package B's documentation may require Package A's documentation to be compiled first, in order to resolve references.