### PR TITLE
parser: ignore CDATA in .autodoc parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 This file describes changes in the AutoDoc package.
 
+## 2026.06.30
+  - Fix a regression in `.autodoc` parsing where Markdown-style headings
+    and AutoDoc commands were interpreted inside XML CDATA blocks instead
+    of being kept as literal text
+
 ## 2026.05.11
   - Fix an issue when running a `makedoc.g` from outside its package's
     directory: if one e.g. did `gap ../somePackage/makedoc.g` and this tried

--- a/gap/Parser.gi
+++ b/gap/Parser.gi
@@ -302,7 +302,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
           filestream, groupnumber, line_number,
           markdown_fence, plain_text_mode, rest_of_file_skipped,
           scope_group, single_line_title_item_list, title_item,
-          title_item_list, xml_comment_mode;
+          title_item_list, xml_comment_mode, cdata_mode;
     groupnumber := 0;
     autodoc_read_line := false;
     context_stack := [ ];
@@ -366,13 +366,24 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         fi;
     end;
     NormalizeInputLine := function( raw_line )
-        local text, comment_pos;
+        local text, comment_pos, line_starts_cdata, line_ends_cdata,
+              is_cdata_line;
         if plain_text_mode then
             text := raw_line;
+            line_starts_cdata := AUTODOC_LineStartsCDATA( raw_line );
+            line_ends_cdata := AUTODOC_LineEndsCDATA( raw_line );
+            is_cdata_line := cdata_mode or line_starts_cdata;
+            if line_starts_cdata then
+                cdata_mode := true;
+            fi;
+            if line_ends_cdata then
+                cdata_mode := false;
+            fi;
             return rec(
                 raw_text := raw_line,
                 text := text,
                 is_autodoc := true,
+                scan_for_autodoc_commands := not is_cdata_line,
                 allows_declaration_scan := false
             );
         fi;
@@ -383,6 +394,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                 raw_text := raw_line,
                 text := raw_line,
                 is_autodoc := false,
+                scan_for_autodoc_commands := false,
                 allows_declaration_scan := false
             );
         fi;
@@ -392,6 +404,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
             raw_text := raw_line,
             text := text,
             is_autodoc := true,
+            scan_for_autodoc_commands := true,
             allows_declaration_scan := true
         );
     end;
@@ -706,6 +719,7 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
         plain_text_mode := false;
         markdown_fence := fail;
         xml_comment_mode := false;
+        cdata_mode := false;
     end;
     ScanForDeclarationPart := function()
         local declare_position;
@@ -1278,9 +1292,12 @@ InstallGlobalFunction( AutoDoc_Parser_ReadFiles,
                 fi;
             fi;
 
-            if current_line_info.is_autodoc then
+            if current_line_info.scan_for_autodoc_commands then
                 current_line_fence := MarkdownFenceFromLine( current_line_info.text );
                 current_command := Scan_for_AutoDoc_Part( current_line_info.text );
+            elif current_line_info.is_autodoc then
+                current_line_fence := fail;
+                current_command := [ "STRING", current_line_info.text ];
             else
                 current_line_fence := fail;
                 current_command := [ false, current_line ];

--- a/tst/worksheets/autoplain.expected/_Chapter_Test.xml
+++ b/tst/worksheets/autoplain.expected/_Chapter_Test.xml
@@ -53,6 +53,13 @@ And XML comments should pass through verbatim:
 #  <ManSection>
 #  <#/GAPDoc>
 -->
+And XML CDATA blocks should also keep would-be commands literal:
+<Listing><![CDATA[
+# PlainCDATAHeading
+## PlainCDATASection
+@Section PlainCDATACommand
+#! PlainCDATAComment
+]]></Listing>
 And we wrap up with some dummy text
 </Subsection>
 

--- a/tst/worksheets/autoplain.sheet/plain.autodoc
+++ b/tst/worksheets/autoplain.sheet/plain.autodoc
@@ -44,4 +44,11 @@ And XML comments should pass through verbatim:
 #  <ManSection>
 #  <#/GAPDoc>
 -->
+And XML CDATA blocks should also keep would-be commands literal:
+<Listing><![CDATA[
+# PlainCDATAHeading
+## PlainCDATASection
+@Section PlainCDATACommand
+#! PlainCDATAComment
+]]></Listing>
 And we wrap up with some dummy text


### PR DESCRIPTION
Keep plain-text .autodoc CDATA blocks literal during parsing.

Co-authored-by: Codex <codex@openai.com>
